### PR TITLE
Sync nested typechecking boilerplate from baked Ruby app reference

### DIFF
--- a/.cursor/rules/template-hierarchy.mdc
+++ b/.cursor/rules/template-hierarchy.mdc
@@ -18,7 +18,8 @@ Cookiecutter templates in this family stack **general → specific** (meta → l
 | `template-hierarchy.mdc` | Yes | Yes (this file) | Yes (project tier) |
 | `fix.sh`, `bin/git-*` hooks, `.githooks/post-checkout`, shared `.overcommit.yml` bootstrap | Yes | Yes | Yes |
 | Boilerplate sync skill + `SYNCING_BOILERPLATE.md` | Baked path only | **Yes** | No |
-| Language hooks (RuboCop, etc.) | No | **Yes** | Framework-only → nested |
+| Language hooks (RuboCop, etc.) | No | Generic only (template `ALL.exclude`) | **Yes** — baked gem hooks |
+| Sorbet / Tapioca / Solargraph (gems, `fix.sh` rugged, `.overcommit.yml` Ruby hooks, `Makefile` typecheck targets, CircleCI `ruby-types` cache) | No | **No** — top level is cookiecutter maintenance (pytest/mypy) | **Yes** — nested `{{cookiecutter.project_slug}}/` only |
 | Pytest bake tips in `DEVELOPMENT.md` | Meta repo | **Yes** if this template uses pytest | No — not every baked project uses Python |
 
 Place each artifact at the **narrowest** tier that still applies to every repo that tier generates.
@@ -62,7 +63,7 @@ When porting config that names directories or tools (`.envrc` `PATH_add`, Makefi
 | `fix.sh` rbenv / `set_ruby_local_version` | **Do not port churn from Ruby app refs** | Ruby toolchain when this is a Ruby template | **`rugged`** (Ruby/undercover), `handlebars`, `mini_racer`, `chromedriver` |
 | `.gitignore` Sorbet / Tapioca / YARD | **Do not port from Ruby app refs** | `tapioca.installed`, `yardoc.installed`, `sorbet/*` | Generated RBI paths |
 | `.git-hooks` `# @sg-ignore` | **Do not port** | Sorbet annotations only in Ruby templates | — |
-| `.circleci` | `no_output_timeout`, shared cache pattern | Same | `method: full`, `pwd`, `*.gemspec` cache keys |
+| `.circleci` | `no_output_timeout`, shared cache pattern; **citest** child-rbenv for bake tests | Same — no `ruby-types` / Sorbet caches at repo root | Custom checkout (undercover), `ruby-types-v3`, typecheck job, RBI artifacts |
 
 When syncing from a **baked** private reference, read [SYNCING_BOILERPLATE.md](../docs/SYNCING_BOILERPLATE.md) § baked Ruby apps — do not paste the reference’s full `.overcommit.yml` or Ruby yamllint/Sorbet blocks into cookiecutter templates, and do not name private reference repos in public text.
 

--- a/.git-hooks/pre_commit/circle_ci.rb
+++ b/.git-hooks/pre_commit/circle_ci.rb
@@ -11,15 +11,13 @@ module Overcommit
       class CircleCi < Base
         # @return [Symbol, Array<Symbol, String>]
         def run
+          # @type [Overcommit::Subprocess::Result]
           result = execute(command)
-          # @sg-ignore
           return :pass if result.success?
 
-          # @sg-ignore
           if result.success?
             :pass
           else
-            # @sg-ignore
             [:fail, result.stderr]
           end
         end

--- a/.git-hooks/pre_commit/punchlist.rb
+++ b/.git-hooks/pre_commit/punchlist.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require 'overcommit'
@@ -11,7 +12,7 @@ module Overcommit
       class Punchlist < Base
         # @param stdout [String]
         # @return [Array<Overcommit::Hook::Message>]
-        # @sg-ignore
+        # @sg-ignore Message.new inferred as Punchlist in this hook class
         def parse_output(stdout)
           stdout.split("\n").map do |line|
             file, line_no, _message = line.split(':', 3)

--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -54,12 +54,11 @@ commands:
       - restore_cache:
           name: Restore ruby-types cache
           keys:
-            - ruby-types-v2-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-{% raw %}{{ checksum ".circleci/config.yml" }}{% endraw %}- # yamllint disable-line rule:line-length
-            - ruby-types-v2-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-
-            - ruby-types-v2-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-
-            - ruby-types-v2-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-
-            - ruby-types-v2-
-            - ruby-types-
+            - ruby-types-v3-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-{% raw %}{{ checksum ".circleci/config.yml" }}{% endraw %}-
+            - ruby-types-v3-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-
+            - ruby-types-v3-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-
+            - ruby-types-v3-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-
+            - ruby-types-v3-
       - restore_cache:
           name: Restore pyenv cache
           keys:
@@ -243,7 +242,7 @@ jobs:
           path: rbi/{{cookiecutter.project_slug}}.rbi
       - save_cache:
           name: 'Save ruby-types cache'
-          key: ruby-types-v2-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-{% raw %}{{ checksum ".circleci/config.yml" }}{% endraw %}-{% raw %}{{ checksum ".ruby-version" }}{% endraw %}-{% raw %}{{ checksum {% endraw %}"rbi/{{cookiecutter.project_slug}}.rbi" {% raw %}}}{% endraw %}  # yamllint disable-line rule:line-length
+          key: ruby-types-v3-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-{% raw %}{{ checksum ".circleci/config.yml" }}{% endraw %}-{% raw %}{{ checksum ".ruby-version" }}{% endraw %}-{% raw %}{{ checksum {% endraw %}"rbi/{{cookiecutter.project_slug}}.rbi" {% raw %}}}{% endraw %}  # yamllint disable-line rule:line-length
           paths:
             - ".yardoc"
             - 'yarddoc'
@@ -255,6 +254,8 @@ jobs:
             - "tapioca.installed"
             - "sorbet/machine_specific_config"
             - "rbi/{{cookiecutter.project_slug}}.rbi"
+            - ".gem_rbs_collection"
+            - "rbs_collection.lock.yaml"
       - run_with_languages:
           label: Test
           command: |

--- a/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/circle_ci.rb
+++ b/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/circle_ci.rb
@@ -11,15 +11,13 @@ module Overcommit
       class CircleCi < Base
         # @return [Symbol, Array<Symbol, String>]
         def run
+          # @type [Overcommit::Subprocess::Result]
           result = execute(command)
-          # @sg-ignore
           return :pass if result.success?
 
-          # @sg-ignore
           if result.success?
             :pass
           else
-            # @sg-ignore
             [:fail, result.stderr]
           end
         end

--- a/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/punchlist.rb
+++ b/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/punchlist.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require 'overcommit'
@@ -11,7 +12,7 @@ module Overcommit
       class Punchlist < Base
         # @param stdout [String]
         # @return [Array<Overcommit::Hook::Message>]
-        # @sg-ignore
+        # @sg-ignore Message.new inferred as Punchlist in this hook class
         def parse_output(stdout)
           stdout.split("\n").map do |line|
             file, line_no, _message = line.split(':', 3)

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -37,7 +37,7 @@ rbi/{{cookiecutter.project_slug}}.rbi: tapioca.installed yardoc.installed sorbet
 	rm -f rbi/{{cookiecutter.project_slug}}.rbi.bak
 	touch rbi/{{cookiecutter.project_slug}}.rbi
 
-sig/{{cookiecutter.project_slug}}.rbs: yardoc.installed gem_rbs_collection/.keepme ## Generate RBS file
+sig/{{cookiecutter.project_slug}}.rbs: yardoc.installed .gem_rbs_collection/.keepme ## Generate RBS file
 	rm -f rbi/{{cookiecutter.project_slug}}.rbs
 	bin/sord gen $(SORD_GEN_OPTIONS) sig/{{cookiecutter.project_slug}}.rbs # YARD to RBS
 
@@ -80,7 +80,7 @@ rbs_collection.yaml:
 	touch .gem_rbs_collection/.keepme
 
 ci-build-typecheck: build-typecheck  ## Ensure cache is filled for CI to save regardless of actions run
-	bundle exec solargraph gems
+	bin/solargraph gems
 
 # Only create this once, so no dependencies
 sorbet/tapioca/require.rb:
@@ -94,7 +94,7 @@ tapioca.installed: sorbet/tapioca/require.rb Gemfile.lock.installed ## Install T
 #	bin/tapioca dsl
 	touch tapioca.installed
 
-yardoc.installed: $(wildcard config/annotations_*.rb) $(SOURCE_FILES) ## Generate YARD documentation
+yardoc.installed: Makefile $(wildcard config/annotations_*.rb) $(SOURCE_FILES) ## Generate YARD documentation
 	bin/yard doc $(YARD_OPTS)
 	touch yardoc.installed
 
@@ -140,7 +140,10 @@ solargraph-strong: build-typecheck ## Run Solargraph typechecker
 
 typecheck: build-typecheck srb solargraph ## validate types in code and configuration
 
-citypecheck: ci-build-typecheck srb solargraph ## Run type check from CircleCI
+citypecheck: ci-build-typecheck srb ci-solargraph ## Run type check from CircleCI
+
+ci-solargraph: ## Run Solargraph typechecker in CI
+	bin/solargraph typecheck --level strong
 
 typecoverage: typecheck ## Run type checking and then ratchet coverage in metrics/
 


### PR DESCRIPTION
## Summary

- Updates the **nested** `{{cookiecutter.project_slug}}/` template only (not repo-root typechecking): CircleCI `ruby-types-v3` cache keys and paths for `.gem_rbs_collection` / `rbs_collection.lock.yaml`; Makefile fixes for Solargraph/RBS (`bin/solargraph`, `.gem_rbs_collection`, `ci-solargraph` in `citypecheck`, `yardoc.installed` deps).
- Aligns root and nested pre-commit hooks (`circle_ci.rb` `@type`, `punchlist.rb` `# typed: true` + clearer `@sg-ignore`).
- Documents tier placement in `template-hierarchy.mdc` (Sorbet/Tapioca/Solargraph and CircleCI type caches belong in the nested baked-gem layer).

## Test plan

- [x] `pytest tests/test_bake_project.py`
- [ ] After bake: `make citypecheck` in a generated project (CircleCI parity)


Made with [Cursor](https://cursor.com)