### PR TITLE
Use full CircleCI checkout and harden undercover rake

### DIFF
--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -33,7 +33,8 @@ commands:
   set_up_environment:
     description: "Install source environment"
     steps:
-      - checkout
+      - checkout:
+          method: full
       - run:
           name: Update timestamps to original commit time
           command: |

--- a/{{cookiecutter.project_slug}}/rakelib/undercover.rake
+++ b/{{cookiecutter.project_slug}}/rakelib/undercover.rake
@@ -1,11 +1,25 @@
 # frozen_string_literal: true
 
+UNDERCOVER_EXCLUDE_FILES =
+  "lib/{{ cookiecutter.project_slug }}/version.rb,'test/**/*,test/*,rakelib/*,script/*'"
+
+def origin_main_ref?
+  system(
+    'git', 'rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main',
+    out: File::NULL, err: File::NULL
+  )
+end
+
 desc 'Ensure PR changes are fully covered by tests'
-task :undercover do |_t|
-  ret =
-    system("if git branch -r | grep origin/main; then undercover --compare origin/main --exclude-files " \
-           "lib/checkoff/version.rb," \
-           "'test/**/*,test/*,rakelib/*';" \
-           "fi")
-  raise unless ret
+task :undercover do
+  unless origin_main_ref?
+    message = 'origin/main is not available; cannot run undercover'
+    abort "ERROR: #{message}" if ENV['CIRCLECI']
+
+    warn "Skipping undercover: #{message}"
+    next
+  end
+
+  sh 'undercover', '--compare', 'origin/main',
+     '--exclude-files', UNDERCOVER_EXCLUDE_FILES
 end

--- a/{{cookiecutter.project_slug}}/rakelib/undercover.rake
+++ b/{{cookiecutter.project_slug}}/rakelib/undercover.rake
@@ -3,18 +3,19 @@
 UNDERCOVER_EXCLUDE_FILES =
   "lib/{{ cookiecutter.project_slug }}/version.rb,'test/**/*,test/*,rakelib/*,script/*'"
 
+# @return [Boolean]
 def origin_main_ref?
   system(
     'git', 'rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main',
     out: File::NULL, err: File::NULL
-  )
+  ) == true
 end
 
 desc 'Ensure PR changes are fully covered by tests'
 task :undercover do
   unless origin_main_ref?
     message = 'origin/main is not available; cannot run undercover'
-    abort "ERROR: #{message}" if ENV['CIRCLECI']
+    abort "ERROR: #{message}" if system('test -n "${CIRCLECI:-}"') == true
 
     warn "Skipping undercover: #{message}"
     next


### PR DESCRIPTION
## Summary

- Use CircleCI built-in checkout with `method: full` so generated Ruby projects have full git history for undercover.
- Replace the fragile `git branch -r | grep` undercover rake logic with `origin_main_ref?`, explicit CI failure when `origin/main` is missing, and `project_slug`-based exclude paths (including `script/*`).

## Test plan

- [ ] CircleCI `citest` passes on this PR
- [ ] Nested template `rakelib/undercover.rake` renders correct `lib/<project_slug>/version.rb` exclude path when cookiecutter is run


Made with [Cursor](https://cursor.com)