### PR TITLE
Add solargraph-typecheck Cursor skill to nested template

### DIFF
--- a/{{cookiecutter.project_slug}}/.cursor/skills/solargraph-typecheck/SKILL.md
+++ b/{{cookiecutter.project_slug}}/.cursor/skills/solargraph-typecheck/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: solargraph-typecheck
+description: >-
+  Fix Solargraph typecheck issues, run "make solargraph", update @sg-ignore
+  comments, resolve strong/typed typecheck failures, or work on YARD typing
+  after a Solargraph upgrade in this Ruby gem.
+version: 1.0.0
+---
+
+# Solargraph typecheck
+
+Resolve Solargraph problems in this repo without re-learning project conventions each time.
+
+## Environment
+
+Always run project tooling through **direnv** so `.envrc` loads secrets and `bin/` is on `PATH`:
+
+```bash
+direnv allow
+direnv exec . ./fix.sh          # first-time / cold setup
+direnv exec . make build-typecheck
+direnv exec . make solargraph-strong
+```
+
+- `./fix.sh` needs `bin/install_package` and friends; do not run bare `./fix.sh` without direnv.
+- `make build-typecheck` depends on `.ruby-version`, yard/tapioca artifacts, `rbi/{{cookiecutter.project_slug}}.rbi`, and updates the RBS gem collection via `bin/rbs collection update`.
+
+## Which level to use
+
+| Target | Command | Notes |
+|--------|---------|-------|
+| Local default | `make solargraph-strong` | Same as `make solargraph`; must be clean |
+| CI | `make ci-solargraph` | Strong level; see `Makefile` |
+| Full gate | `make typecheck` | Sorbet + Solargraph strong |
+
+## Scope
+
+See `.solargraph.yml` for include/exclude paths and reporter settings. Mock-heavy test directories (`spec/`, `feature/`, or `test/`) are often excluded from strong typecheck — add paths under `exclude:` rather than thousands of per-line ignores in tests.
+
+## Workflow
+
+1. Run `direnv exec . make build-typecheck` if pins/RBI/RBS collection may be stale.
+2. Run `direnv exec . make solargraph-strong 2>&1 | tee /tmp/sg-typecheck.txt`.
+3. Triage by message type (see below): fix easy issues first, then targeted `@sg-ignore`.
+4. Re-run until zero problems.
+5. Run `direnv exec . bin/rubocop` — bulk `@return [void]` or layout fixes often need `rubocop -A`.
+
+Optional helpers (use after manual triage, not as a blind hammer):
+
+```bash
+direnv exec . bundle exec solargraph typecheck --level strong 2>&1 | tee /tmp/sg-typecheck.txt
+ruby .cursor/skills/solargraph-typecheck/scripts/apply_solargraph_typecheck.rb /tmp/sg-typecheck.txt
+ruby .cursor/skills/solargraph-typecheck/scripts/strip_sg_ignore.rb path/to/file_or_dir.rb
+```
+
+## `@sg-ignore` rules (Solargraph 0.59+)
+
+- Applies to the **next AST node only** — one ignore per statement (or put ignore immediately before the failing line).
+- **Unneeded @sg-ignore** means remove that comment; Solargraph 0.59 reports stale ignores after upgrades.
+- Do **not** write the literal text `@sg-ignore` in normal comments or file headers — Solargraph treats it as a directive (`Unneeded @sg-ignore` on unrelated lines). Say "ignore comment" in prose instead.
+- Prefer **fixes** over ignores when cheap (YARD `@param`, `String(...)`, `attr_reader`, nil guards).
+
+## Fix patterns (prefer these over ignores)
+
+### YARD `@param` widening
+
+CLI and option helpers may accept symbols from [GLI](https://github.com/davydovanton/gli) (Gem Library Interface) defaults. When strong reports `expected String, received String, Symbol`, widen the callee's `@param`:
+
+```ruby
+# @param workspace_name [String, Symbol]
+```
+
+Propagate along call chains as errors move upstream.
+
+### Use accessors instead of `@ivar` in subclasses
+
+If a base class defines `@tasks` in `initialize`, add documented `attr_reader`s and call `tasks`, not `@tasks`, in subclasses.
+
+### Nil narrowing
+
+Solargraph often ignores `raise` guards. Options:
+
+- Explicit `@type [SomeClass]` after guard, or
+- `# @sg-ignore nil check above is not flow-sensitive` on the next line.
+
+### `Date.new` vs RBS 4
+
+Strong may report `Not enough arguments to Date.new` for `Date.new(2029, 1, 4)`. Prefer:
+
+```ruby
+Date.parse('2029-01-04')
+```
+
+### Duck types and unknown stdlib
+
+- HTTP response bodies: `@param response [#read_body]`
+- `$LOAD_PATH`: one `# @sg-ignore` on the bootstrap line (special RBS typing)
+- Bundler binstub `ENV['BUNDLE_GEMFILE'] ||= ...`: YARD stubs in `config/annotations_misc.rb` do not override RBS `ENVClass` at strong level — keep `# @sg-ignore` on each binstub line
+
+### GLI command blocks
+
+Solargraph does not see `c.flag` / `c.action`. Put `# @sg-ignore` **immediately before each** `c.flag` / `c.action` line inside the block (one ignore does not cover the whole block).
+
+### `Gem::Specification` in `*.gemspec`
+
+Dynamic setters are invisible to Solargraph. Use one `# @sg-ignore` per `spec.*` / `add_dependency` line (and the `$LOAD_PATH` line).
+
+### Overcommit hooks
+
+Subprocess results need an explicit type:
+
+```ruby
+# @type [Overcommit::Subprocess::Result]
+result = execute(...)
+```
+
+### Predicate methods returning Boolean
+
+Methods that return `true`/`false` but mutate state may trigger RuboCop `Naming/PredicateMethod` if named `fix_*!`. For maintenance scripts, use a scoped `# rubocop:disable` block rather than renaming call sites.
+
+## When to ignore
+
+Use `@sg-ignore` for:
+
+- GLI DSL, gemspec DSL, Mocha-heavy code (prefer `.solargraph.yml` exclude for tests instead)
+- Inferred return type on simple `any?` / `include?` blocks where YARD already says `@return [Boolean]`
+- Third-party API fields without complete RBI pins
+
+Avoid:
+
+- Blanket `@sg-ignore` in test files (use `.solargraph.yml` exclude)
+- Chained `@sg-ignore` on lines that no longer fail (causes **Unneeded @sg-ignore**)
+- Mass automated ignore insertion without re-running typecheck (creates ignore/remove oscillation)
+
+## `script/` files
+
+Scripts under `script/` should be **typed** (`# typed: true`) when typechecked:
+
+- Use a small class instead of `Struct` for YARD clarity.
+- Document all methods with `@param` / `@return`.
+- Avoid `@sg-ignore` in comments that are not actual directives.
+
+## Rubocop fallout
+
+After adding many `# @return [void]` lines in tests (historical) or editing scripts:
+
+```bash
+direnv exec . bin/rubocop -A
+```
+
+Watch for `Lint/DuplicateMethods` when a test class both `def_delegators :@mocks, :foo` and defines `def foo`.
+
+## Success criteria
+
+```bash
+direnv exec . make solargraph-strong   # 0 problems
+direnv exec . bin/rubocop              # no offenses
+```
+
+## Additional resources
+
+- **`references/issue-catalog.md`** — common Solargraph messages and responses
+- **`scripts/apply_solargraph_typecheck.rb`** — parse typecheck output and apply targeted fixes
+- **`scripts/strip_sg_ignore.rb`** — bulk-remove standalone `# @sg-ignore` lines

--- a/{{cookiecutter.project_slug}}/.cursor/skills/solargraph-typecheck/references/issue-catalog.md
+++ b/{{cookiecutter.project_slug}}/.cursor/skills/solargraph-typecheck/references/issue-catalog.md
@@ -1,0 +1,79 @@
+# Solargraph issue catalog
+
+Quick lookup for strong-level messages seen in Ruby gem repos and the preferred response.
+
+## Unneeded @sg-ignore comment
+
+**Cause:** Stale ignore after Solargraph upgrade, or `@sg-ignore` text in a non-directive comment.
+
+**Fix:** Remove the `# @sg-ignore` line. Reword comments that mention `@sg-ignore` literally.
+
+## Missing @return tag for Class#method
+
+**Cause:** Strong level requires YARD return tags on documented methods.
+
+**Fix:** Add `# @return [void]` for test helpers and side-effect methods; use an accurate type elsewhere. After bulk adds, run `rubocop -A` for comment indentation.
+
+## Wrong argument type … expected String, received String, Symbol
+
+**Cause:** CLI/options pass symbols; YARD on callee only documents `String`.
+
+**Fix:** Widen `@param` to `[String, Symbol]` on the method definition (and upstream if the error moves).
+
+## Unresolved call to @tasks / @timelines / @custom_fields
+
+**Cause:** Subclass uses ivars; Solargraph only knows documented accessors.
+
+**Fix:** Add `attr_reader` with `@return` types on the base class; call `tasks` not `@tasks`.
+
+## Unresolved call to flag / action (GLI)
+
+**Cause:** GLI block DSL has no RBI.
+
+**Fix:** `# @sg-ignore` on the line immediately before each `c.flag` / `c.action`.
+
+## Unresolved call to name= / add_dependency (gemspec)
+
+**Cause:** `Gem::Specification` dynamic API.
+
+**Fix:** One `# @sg-ignore` per assignment line in `*.gemspec`.
+
+## Not enough arguments to Date.new
+
+**Cause:** RBS 4 / Solargraph stricter `Date.new` signature.
+
+**Fix:** `Date.parse('YYYY-MM-DD')` or `@sg-ignore` on that line.
+
+## Declared return type … does not match inferred type … nil
+
+**Cause:** Method raises on nil but Solargraph does not narrow (common for `*_or_raise` helpers).
+
+**Fix:** `# @sg-ignore` on the method line with a short reason, or refactor to explicit early return with typed local.
+
+## Return type could not be inferred
+
+**Cause:** Last expression type opaque (e.g. `hash.keys.any? { … }`).
+
+**Fix:** Add explicit `return`, cast with `@type`, or `# @sg-ignore` on the `def` line if `@return [Boolean]` is already documented.
+
+## Unresolved call to success? / stdout (Overcommit)
+
+**Cause:** `execute` return type unknown.
+
+**Fix:** `# @type [Overcommit::Subprocess::Result]` on the assignment line.
+
+## Unresolved call to [] on RBS::Unnamed::ENVClass (binstubs)
+
+**Cause:** `$LOAD_PATH`-style special typing in binstubs.
+
+**Fix:** Usually ignorable on the `ENV['BUNDLE_GEMFILE']` line; binstubs are often excluded or get a single ignore.
+
+## Wrong argument type … Mocha::Mock
+
+**Cause:** Test mocks in spec/feature/test files.
+
+**Fix:** Exclude mock-heavy test paths in `.solargraph.yml` (`spec/**/*`, `feature/**/*`, or `test/**/*`); do not strong-typecheck tests.
+
+## Performance note
+
+Do not loop `.cursor/skills/solargraph-typecheck/scripts/apply_solargraph_typecheck.rb` dozens of times — ignores only cover the next line, so automated passes can add/remove in oscillation. Triage by file, fix `lib/` properly, exclude tests, then use targeted ignores.

--- a/{{cookiecutter.project_slug}}/.cursor/skills/solargraph-typecheck/scripts/apply_solargraph_typecheck.rb
+++ b/{{cookiecutter.project_slug}}/.cursor/skills/solargraph-typecheck/scripts/apply_solargraph_typecheck.rb
@@ -1,0 +1,203 @@
+#!/usr/bin/env ruby
+# typed: true
+# frozen_string_literal: true
+
+# rubocop:disable Naming/PredicateMethod, Metrics/AbcSize, Metrics/MethodLength
+
+# Applies solargraph typecheck output: removes unneeded ignore lines and
+# inserts ignore comments before remaining reported lines (unless already ignored).
+
+require 'pathname'
+
+ROOT = Pathname(File.expand_path('../../../..', __dir__))
+
+# One reported typecheck problem.
+class Issue
+  # @return [String]
+  attr_reader :file
+
+  # @return [Integer]
+  attr_reader :line
+
+  # @return [String]
+  attr_reader :message
+
+  # @param file [String]
+  # @param line [Integer]
+  # @param message [String]
+  # @return [void]
+  def initialize(file:, line:, message:)
+    @file = file
+    @line = line
+    @message = message
+  end
+end
+
+# @param path [String]
+# @return [Array<Issue>]
+def parse_issues(path)
+  File.readlines(path).filter_map do |raw|
+    stripped = raw.strip
+    match = stripped.match(/\A(.+):(\d+) - (.+)\z/)
+    next unless match
+
+    file = Pathname(match[1].to_s).expand_path
+    Issue.new(file: file.to_s, line: match[2].to_i, message: match[3].to_s.strip)
+  end
+end
+
+# @param path [String]
+# @return [Array<String>]
+def read_lines(path)
+  File.readlines(path, chomp: false)
+end
+
+# @param path [String]
+# @param lines [Array<String>]
+# @return [void]
+def write_lines(path, lines)
+  File.write(path, lines.join)
+end
+
+# @param line [String, nil]
+# @return [Boolean]
+def sg_ignore_line?(line)
+  return false if line.nil?
+
+  line.strip == '# @sg-ignore'
+end
+
+# @param lines [Array<String>]
+# @param line_num [Integer]
+# @return [Integer, nil]
+def find_sg_ignore_index(lines, line_num)
+  idx = line_num - 1
+  return idx if idx >= 0 && sg_ignore_line?(lines[idx])
+
+  start = [idx - 1, 0].max
+  finish = [idx - 20, 0].max
+  start.downto(finish) do |i|
+    return i if sg_ignore_line?(lines[i])
+  end
+  nil
+end
+
+# @param issue [Issue]
+# @return [Boolean]
+def remove_sg_ignore!(issue)
+  lines = read_lines(issue.file)
+  ignore_idx = find_sg_ignore_index(lines, issue.line)
+  return false unless ignore_idx
+
+  lines.delete_at(ignore_idx)
+  write_lines(issue.file, lines)
+  true
+end
+
+# @param lines [Array<String>]
+# @param line_num [Integer]
+# @return [Boolean]
+def already_ignored?(lines, line_num)
+  idx = line_num - 1
+  idx.positive? && sg_ignore_line?(lines[idx - 1])
+end
+
+# @param issue [Issue]
+# @return [Boolean]
+def add_sg_ignore!(issue)
+  lines = read_lines(issue.file)
+  idx = issue.line - 1
+  return false if idx.negative? || already_ignored?(lines, issue.line)
+
+  line = lines[idx]
+  indent = ''
+  if line
+    indent_match = line.match(/\A(\s*)/)
+    indent = indent_match.captures.first if indent_match
+  end
+  lines.insert(idx, "#{indent}# @sg-ignore\n")
+  write_lines(issue.file, lines)
+  true
+end
+
+# @param issue [Issue]
+# @return [Boolean]
+def fix_missing_return!(issue)
+  match = issue.message.match(/\AMissing @return tag for (\S+)#(\S+)\z/)
+  return false unless match
+
+  _klass, method_name = match.captures
+  lines = read_lines(issue.file)
+  insert_at = insert_at_for_missing_return(lines, issue.line, method_name)
+  return false unless insert_at
+
+  unless lines[insert_at - 1]&.include?('@return')
+    lines.insert(insert_at, "# @return [void]\n")
+    write_lines(issue.file, lines)
+    return true
+  end
+  false
+end
+
+# @param lines [Array<String>]
+# @param line_num [Integer]
+# @param method_name [String]
+# @return [Integer, nil]
+def insert_at_for_missing_return(lines, line_num, method_name)
+  def_idx = line_num - 1
+  def_line = lines[def_idx]
+  return nil unless def_line&.match?(/^\s*def\s+#{Regexp.escape(method_name)}\b/)
+
+  insert_at = def_idx
+  while insert_at.positive?
+    prev = lines[insert_at - 1]
+    break unless prev&.match?(/^\s*#/)
+
+    insert_at -= 1
+  end
+  insert_at
+end
+
+# @param issue [Issue]
+# @return [Boolean]
+def fix_date_new!(issue)
+  return false unless issue.message == 'Not enough arguments to Date.new'
+
+  lines = read_lines(issue.file)
+  idx = issue.line - 1
+  line = lines[idx]
+  return false if line.nil?
+  return false unless line.include?('Date.new(')
+
+  date_match = line.match(/Date\.new\((\d+),\s*(\d+),\s*(\d+)\)/)
+  return false unless date_match
+
+  year, month, day = date_match.captures
+  lines[idx] = line.gsub(
+    "Date.new(#{year}, #{month}, #{day})",
+    "Date.parse('#{year}-#{month.rjust(2, '0')}-#{day.rjust(2, '0')}')"
+  )
+  write_lines(issue.file, lines)
+  true
+end
+
+issues_path = ARGV.fetch(0) { abort("usage: #{$PROGRAM_NAME} TYPECHECK_OUTPUT_FILE") }
+issues = parse_issues(issues_path)
+
+unneeded = issues.select { |i| i.message == 'Unneeded @sg-ignore comment' }
+missing_return = issues.select { |i| i.message.start_with?('Missing @return tag for ') }
+date_new = issues.select { |i| i.message == 'Not enough arguments to Date.new' }
+remaining = issues - unneeded - missing_return - date_new
+remaining = remaining.uniq { |i| [i.file, i.line] }
+
+removed = unneeded.count { |i| remove_sg_ignore!(i) }
+fixed_returns = missing_return.count { |i| fix_missing_return!(i) }
+fixed_dates = date_new.count { |i| fix_date_new!(i) }
+added = remaining.count { |i| add_sg_ignore!(i) }
+
+warn "removed #{removed} unneeded @sg-ignore"
+warn "fixed #{fixed_returns} missing @return"
+warn "fixed #{fixed_dates} Date.new"
+warn "added #{added} @sg-ignore"
+
+# rubocop:enable Naming/PredicateMethod, Metrics/AbcSize, Metrics/MethodLength

--- a/{{cookiecutter.project_slug}}/.cursor/skills/solargraph-typecheck/scripts/strip_sg_ignore.rb
+++ b/{{cookiecutter.project_slug}}/.cursor/skills/solargraph-typecheck/scripts/strip_sg_ignore.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+# typed: true
+# frozen_string_literal: true
+
+# Removes standalone Solargraph ignore-comment lines from paths given as arguments.
+
+require 'pathname'
+
+ROOT = Pathname(File.expand_path('../../../..', __dir__))
+
+# @param arg [String]
+# @return [Array<Pathname>]
+def paths_for_arg(arg)
+  path = Pathname(arg)
+  path = ROOT.join(arg) unless path.absolute?
+  if path.directory?
+    path.glob('**/*.rb')
+  else
+    [path]
+  end
+end
+
+paths = ARGV.flat_map { |arg| paths_for_arg(arg) }
+
+changed = 0
+paths.each do |file|
+  next unless file.file?
+
+  lines = File.readlines(file, chomp: false)
+  filtered = lines.reject { |line| line.strip == '# @sg-ignore' }
+  next if filtered.size == lines.size
+
+  File.write(file, filtered.join)
+  changed += 1
+  warn "stripped #{file.relative_path_from(ROOT)}"
+end
+
+warn "updated #{changed} files"

--- a/{{cookiecutter.project_slug}}/.overcommit.yml
+++ b/{{cookiecutter.project_slug}}/.overcommit.yml
@@ -102,6 +102,8 @@ PreCommit:
       - "bin/*"
       - "bin/overcommit_branch"
     exclude:
+      # Cursor skills/scripts are agent tooling, not gem API surface
+      - '.cursor/**/*'
       # vendored
       - 'bin/bundle'
       - 'bin/brakeman'

--- a/{{cookiecutter.project_slug}}/.solargraph.yml
+++ b/{{cookiecutter.project_slug}}/.solargraph.yml
@@ -14,6 +14,8 @@ include:
   - "bin/*"
   - "bin/overcommit_branch"
 exclude:
+  # Cursor skills/scripts are agent tooling, not gem API surface
+  - '.cursor/**/*'
   # vendored
   - 'bin/bundle'
   - 'bin/brakeman'


### PR DESCRIPTION
## Summary

- Add `.cursor/skills/solargraph-typecheck/` to the nested project template: skill guide, issue catalog, and helper scripts (`apply_solargraph_typecheck.rb`, `strip_sg_ignore.rb`).
- Exclude `.cursor/**/*` from Solargraph typecheck in `.solargraph.yml` and from the Overcommit Solargraph hook so agent tooling under `.cursor/` is not strong-typechecked with gem code.

## Test plan

- [x] CI passes (`build`, `quality`)
- [x] Baked project `make typecheck` and `make quality` succeed with the skill scripts present
- [ ] Review skill content for generic baked-gem applicability