### PR TITLE
Worktree-safe update_from_cookiecutter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,7 @@ commands:
 
             # export FIX_SH_TIMING_LOG=/tmp/child_fix_sh_timing.log
 
+            make test-worktree-upgrader-shim
             make citest cicoverage
       - store_artifacts:
           path: /tmp/child_fix_sh_timing.log

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,6 +32,32 @@ bootstrap can cause overcommit signature mismatches even after
 re-signing — see
 [.cursor/rules/overcommit-signing.mdc](.cursor/rules/overcommit-signing.mdc).
 
+## `make update_from_cookiecutter` and worktrees
+
+You can run the full target from a **linked worktree** (for example a Cursor
+feature worktree). Shared git data is one repo; each worktree has its own
+working directory and branch.
+
+1. **`bin/cookiecutter_project_upgrader_with_worktree_shim.sh`** — In a linked
+   worktree, `.git` is a `gitdir:` file, not a directory.
+   `cookiecutter_project_upgrader` expects to write under `.git/cookiecutter/`.
+   The shim temporarily symlinks `.git` to `git rev-parse --git-dir`, runs the
+   upgrader (fails closed on error), then restores the pointer. RuboCop/RBS
+   config under the primary checkout may be hidden during the run.
+
+2. **`bin/update_from_cookiecutter_finish.sh`** — Does not `git checkout main`
+   or `cookiecutter-template` (those branches may be checked out elsewhere).
+   It pushes `cookiecutter-template` by ref, fetches the default branch, creates
+   `update-from-cookiecutter-…` from `origin/<default>`, signs overcommit hooks,
+   and merges `cookiecutter-template`.
+
+Before running in a new worktree, bootstrap once (`direnv exec . ./fix.sh`) so
+overcommit signing works. Do not run two updates in parallel (RuboCop hide uses
+files in the primary checkout). Regression test:
+`bin/test_git_worktree_upgrader_shim.sh`.
+
+Override the default branch with `DEFAULT_BRANCH=my-default make update_from_cookiecutter`.
+
 ## Overcommit
 
 This project uses [overcommit](https://github.com/sds/overcommit) for

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-typecheck bundle_install cicoverage citypecheck citest citypecoverage clean clean-build clean-coverage clean-pyc clean-typecheck clean-typecoverage coverage default docs gem_dependencies help overcommit quality repl test typecheck typecoverage update_from_cookiecutter
+.PHONY: build build-typecheck bundle_install cicoverage citypecheck citest citypecoverage clean clean-build clean-coverage clean-pyc clean-typecheck clean-typecoverage coverage default docs gem_dependencies help overcommit quality repl test test-worktree-upgrader-shim typecheck typecoverage update_from_cookiecutter
 
 .DEFAULT_GOAL := default
 
@@ -163,64 +163,11 @@ update_apt: .make/apt_updated
 
 cicoverage: citest ## check code coverage
 
+test-worktree-upgrader-shim: ## Regression test for linked-worktree .git shim
+	bin/test_git_worktree_upgrader_shim.sh
+
 update_from_cookiecutter: ## Bring in changes from template project used to create this repo
 	bin/overcommit --uninstall
 	cookiecutter_project_upgrader --help >/dev/null
-	@mkdir -p .make
-	@if [ -f docs/cookiecutter_input.json ]; then \
-	  jq 'del(._output_dir, ._repo_dir, ._checkout)' docs/cookiecutter_input.json > .make/cookiecutter_context.json; \
-	fi
-	@MAIN_REPO_ROOT=$$(dirname "$$(git rev-parse --git-common-dir)"); \
-	if [ -f "$$MAIN_REPO_ROOT/rbs_collection.yaml" ]; then \
-	  mv "$$MAIN_REPO_ROOT/rbs_collection.yaml" .make/rbs_collection.yaml.bak; \
-	  touch .make/rbs_collection_yaml_hidden; \
-	fi; \
-	if [ -f "$$MAIN_REPO_ROOT/.rubocop.yml" ]; then \
-	  mv "$$MAIN_REPO_ROOT/.rubocop.yml" .make/rubocop-main.yml.bak; \
-	  touch .make/rubocop_main_hidden; \
-	fi; \
-	if [ -f .git ] && [ ! -L .git ]; then \
-	  cp .git .make/git-worktree-pointer; \
-	  GIT_DIR=$$(git rev-parse --git-dir); \
-	  rm -f .git; \
-	  ln -s "$$GIT_DIR" .git; \
-	fi; \
-	if [ -f .make/cookiecutter_context.json ]; then \
-	  IN_COOKIECUTTER_PROJECT_UPGRADER=1 cookiecutter_project_upgrader -c .make/cookiecutter_context.json -p true || true; \
-	else \
-	  IN_COOKIECUTTER_PROJECT_UPGRADER=1 cookiecutter_project_upgrader || true; \
-	fi; \
-	if [ -f .make/git-worktree-pointer ]; then \
-	  rm -f .git; \
-	  mv .make/git-worktree-pointer .git; \
-	fi; \
-	if [ -f .make/rbs_collection_yaml_hidden ]; then \
-	  mv .make/rbs_collection.yaml.bak "$$MAIN_REPO_ROOT/rbs_collection.yaml"; \
-	  rm -f .make/rbs_collection_yaml_hidden; \
-	fi; \
-	if [ -f .make/rubocop_main_hidden ]; then \
-	  mv .make/rubocop-main.yml.bak "$$MAIN_REPO_ROOT/.rubocop.yml"; \
-	  rm -f .make/rubocop_main_hidden; \
-	fi
-	@if ! git diff --quiet -- Makefile 2>/dev/null || ! git diff --cached --quiet -- Makefile 2>/dev/null; then \
-	  git stash push -m 'update_from_cookiecutter Makefile' -- Makefile; \
-	  touch .make/cookiecutter_makefile_stashed; \
-	fi
-	git checkout cookiecutter-template && git push --no-verify
-	git checkout main; overcommit --sign && overcommit --sign pre-commit && overcommit --sign pre-push && git checkout main && git pull && git checkout -b update-from-cookiecutter-$$(date +%Y-%m-%d-%H%M)
-	git merge cookiecutter-template || true
-	git checkout --ours Gemfile.lock || true
-	@if [ -f .make/cookiecutter_makefile_stashed ]; then \
-	  git stash pop; \
-	  rm -f .make/cookiecutter_makefile_stashed; \
-	fi
-	# update frequently security-flagged gems while we're here
-	bundle update --conservative json rexml || true
-	( make build && git add Gemfile.lock ) || true
-	bin/overcommit --install || true
-	@echo
-	@echo "Please resolve any merge conflicts below and push up a PR with:"
-	@echo
-	@echo '   gh pr create --title "Update from cookiecutter" --body "Automated PR to update from cookiecutter boilerplate"'
-	@echo
-	@echo
+	bin/cookiecutter_project_upgrader_with_worktree_shim.sh
+	bin/update_from_cookiecutter_finish.sh

--- a/bin/cookiecutter_project_upgrader_with_worktree_shim.sh
+++ b/bin/cookiecutter_project_upgrader_with_worktree_shim.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Run cookiecutter_project_upgrader from the repo root, including linked git worktrees.
+#
+# cookiecutter_project_upgrader writes under $PWD/.git/cookiecutter/. In a linked
+# worktree, .git is a gitdir: pointer file, not a directory — temporarily symlink .git
+# to $(git rev-parse --git-dir) so os.path.join(..., ".git", "cookiecutter") works.
+#
+# RuboCop can inherit config from MAIN_REPO_ROOT when regenerating under .git/cookiecutter/;
+# optionally hide rbs_collection.yaml and .rubocop.yml there during the run.
+
+set -euo pipefail
+
+MAIN_REPO_ROOT="$(dirname "$(git rev-parse --git-common-dir)")"
+GIT_DIR_PATH="$(git rev-parse --git-dir)"
+MAKE_DIR=".make"
+
+RBS_HIDDEN=0
+RUBOCOP_MAIN_HIDDEN=0
+GIT_WORKTREE_SHIM=0
+
+cleanup() {
+  if [ "${GIT_WORKTREE_SHIM}" -eq 1 ] && [ -f "${MAKE_DIR}/git-worktree-pointer" ]; then
+    rm -f .git
+    mv "${MAKE_DIR}/git-worktree-pointer" .git
+    GIT_WORKTREE_SHIM=0
+  fi
+  if [ "${RBS_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rbs_collection.yaml.bak" ]; then
+    mv "${MAKE_DIR}/rbs_collection.yaml.bak" "${MAIN_REPO_ROOT}/rbs_collection.yaml"
+    rm -f "${MAKE_DIR}/rbs_collection_yaml_hidden"
+    RBS_HIDDEN=0
+  fi
+  if [ "${RUBOCOP_MAIN_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rubocop-main.yml.bak" ]; then
+    mv "${MAKE_DIR}/rubocop-main.yml.bak" "${MAIN_REPO_ROOT}/.rubocop.yml"
+    rm -f "${MAKE_DIR}/rubocop_main_hidden"
+    RUBOCOP_MAIN_HIDDEN=0
+  fi
+  if [ -d "${GIT_DIR_PATH}/cookiecutter" ]; then
+    rm -rf "${GIT_DIR_PATH}/cookiecutter"
+  fi
+}
+
+trap cleanup EXIT
+
+mkdir -p "${MAKE_DIR}"
+
+if [ -f docs/cookiecutter_input.json ]; then
+  jq 'del(._output_dir, ._repo_dir, ._checkout)' docs/cookiecutter_input.json \
+    > "${MAKE_DIR}/cookiecutter_context.json"
+fi
+
+if [ -f "${MAIN_REPO_ROOT}/rbs_collection.yaml" ]; then
+  mv "${MAIN_REPO_ROOT}/rbs_collection.yaml" "${MAKE_DIR}/rbs_collection.yaml.bak"
+  touch "${MAKE_DIR}/rbs_collection_yaml_hidden"
+  RBS_HIDDEN=1
+fi
+if [ -f "${MAIN_REPO_ROOT}/.rubocop.yml" ]; then
+  mv "${MAIN_REPO_ROOT}/.rubocop.yml" "${MAKE_DIR}/rubocop-main.yml.bak"
+  touch "${MAKE_DIR}/rubocop_main_hidden"
+  RUBOCOP_MAIN_HIDDEN=1
+fi
+
+if [ -f .make/git-worktree-pointer ] && [ ! -f .git ] && [ ! -L .git ]; then
+  echo "error: stale ${MAKE_DIR}/git-worktree-pointer but .git is missing; restore manually" >&2
+  exit 1
+fi
+
+if [ -f .git ] && [ ! -L .git ] && grep -q '^gitdir: ' .git; then
+  cp .git "${MAKE_DIR}/git-worktree-pointer"
+  rm -f .git
+  ln -s "${GIT_DIR_PATH}" .git
+  GIT_WORKTREE_SHIM=1
+elif [ -f .git ] && [ ! -L .git ]; then
+  echo "error: .git is a regular file but not a linked-worktree gitdir pointer" >&2
+  exit 1
+fi
+
+export IN_COOKIECUTTER_PROJECT_UPGRADER=1
+upgrader_status=0
+if [ -f "${MAKE_DIR}/cookiecutter_context.json" ]; then
+  cookiecutter_project_upgrader -c "${MAKE_DIR}/cookiecutter_context.json" -p true || upgrader_status=$?
+else
+  cookiecutter_project_upgrader || upgrader_status=$?
+fi
+trap - EXIT
+cleanup
+exit "${upgrader_status}"

--- a/bin/test_git_worktree_upgrader_shim.sh
+++ b/bin/test_git_worktree_upgrader_shim.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Regression test: linked-worktree .git pointer prepare/restore for cookiecutter paths.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SHIM="${ROOT}/bin/cookiecutter_project_upgrader_with_worktree_shim.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+cd "${TMP}"
+git init -q
+echo x > README.md
+git add README.md
+git commit -qm init
+git branch feat
+git worktree add wt feat -q
+
+WT="${TMP}/wt"
+POINTER="${WT}/.git"
+
+if [ ! -f "${POINTER}" ] || ! grep -q '^gitdir: ' "${POINTER}"; then
+  echo "fail: expected gitdir pointer at ${POINTER}" >&2
+  exit 1
+fi
+
+GIT_DIR="$(git -C "${WT}" rev-parse --git-dir)"
+BACKUP="${WT}/.make/git-worktree-pointer-test"
+
+mkdir -p "${WT}/.make"
+cp "${POINTER}" "${BACKUP}"
+rm -f "${POINTER}"
+ln -s "${GIT_DIR}" "${POINTER}"
+
+COOKIECUTTER_DIR="${WT}/.git/cookiecutter/nested"
+if ! mkdir -p "${COOKIECUTTER_DIR}"; then
+  echo "fail: could not mkdir under symlinked .git" >&2
+  exit 1
+fi
+
+rm -f "${POINTER}"
+mv "${BACKUP}" "${POINTER}"
+
+if ! grep -q '^gitdir: ' "${POINTER}"; then
+  echo "fail: .git pointer not restored" >&2
+  exit 1
+fi
+
+if [ -d "${COOKIECUTTER_DIR}" ]; then
+  echo "fail: temp cookiecutter dir should not survive restore" >&2
+  exit 1
+fi
+
+if [ ! -x "${SHIM}" ]; then
+  echo "fail: shim not executable: ${SHIM}" >&2
+  exit 1
+fi
+
+echo "ok: git worktree upgrader shim paths"

--- a/bin/update_from_cookiecutter_finish.sh
+++ b/bin/update_from_cookiecutter_finish.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Finish phase for make update_from_cookiecutter — safe from linked git worktrees.
+#
+# Does not checkout main or cookiecutter-template (those branches may be checked
+# out in another worktree). Uses ref-based push, fetch, switch -c, and merge.
+
+set -euo pipefail
+
+MAKE_DIR=".make"
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+
+if git symbolic-ref -q "refs/remotes/origin/HEAD" >/dev/null 2>&1; then
+  DEFAULT_BRANCH="$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')"
+fi
+
+mkdir -p "${MAKE_DIR}"
+
+if ! git diff --quiet -- Makefile 2>/dev/null || ! git diff --cached --quiet -- Makefile 2>/dev/null; then
+  git stash push -m 'update_from_cookiecutter Makefile' -- Makefile
+  touch "${MAKE_DIR}/cookiecutter_makefile_stashed"
+fi
+
+# Upgrader with -p true already pushed; re-push without checking out the branch.
+git push --no-verify origin cookiecutter-template || true
+
+git fetch "origin" "${DEFAULT_BRANCH}"
+UPDATE_BRANCH="update-from-cookiecutter-$(date +%Y-%m-%d-%H%M)"
+git switch -c "${UPDATE_BRANCH}" "origin/${DEFAULT_BRANCH}"
+echo "Created branch ${UPDATE_BRANCH} from origin/${DEFAULT_BRANCH}"
+
+bin/overcommit --sign
+bin/overcommit --sign pre-commit
+bin/overcommit --sign pre-push
+
+git merge cookiecutter-template || true
+git checkout --ours Gemfile.lock || true
+
+if [ -f "${MAKE_DIR}/cookiecutter_makefile_stashed" ]; then
+  git stash pop || true
+  rm -f "${MAKE_DIR}/cookiecutter_makefile_stashed"
+fi
+
+bundle update --conservative json rexml || true
+( make build && git add Gemfile.lock ) || true
+bin/overcommit --install || true
+
+echo
+echo "Please resolve any merge conflicts below and push up a PR with:"
+echo
+echo '   gh pr create --title "Update from cookiecutter" --body "Automated PR to update from cookiecutter boilerplate"'
+echo

--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -267,6 +267,7 @@ jobs:
             export TZ=America/New_York
             date
 
+            make test-worktree-upgrader-shim
             make citest cicoverage
     # This seemed to shave 5ish% of the build time off when added
     resource_class: large

--- a/{{cookiecutter.project_slug}}/DEVELOPMENT.md
+++ b/{{cookiecutter.project_slug}}/DEVELOPMENT.md
@@ -32,6 +32,32 @@ bootstrap can cause overcommit signature mismatches even after
 re-signing — see
 [.cursor/rules/overcommit-signing.mdc](.cursor/rules/overcommit-signing.mdc).
 
+## `make update_from_cookiecutter` and worktrees
+
+You can run the full target from a **linked worktree** (for example a Cursor
+feature worktree). Shared git data is one repo; each worktree has its own
+working directory and branch.
+
+1. **`bin/cookiecutter_project_upgrader_with_worktree_shim.sh`** — In a linked
+   worktree, `.git` is a `gitdir:` file, not a directory.
+   `cookiecutter_project_upgrader` expects to write under `.git/cookiecutter/`.
+   The shim temporarily symlinks `.git` to `git rev-parse --git-dir`, runs the
+   upgrader (fails closed on error), then restores the pointer. RuboCop/RBS
+   config under the primary checkout may be hidden during the run.
+
+2. **`bin/update_from_cookiecutter_finish.sh`** — Does not `git checkout main`
+   or `cookiecutter-template` (those branches may be checked out elsewhere).
+   It pushes `cookiecutter-template` by ref, fetches the default branch, creates
+   `update-from-cookiecutter-…` from `origin/<default>`, signs overcommit hooks,
+   and merges `cookiecutter-template`.
+
+Before running in a new worktree, bootstrap once (`direnv exec . ./fix.sh`) so
+overcommit signing works. Do not run two updates in parallel (RuboCop hide uses
+files in the primary checkout). Regression test:
+`bin/test_git_worktree_upgrader_shim.sh`.
+
+Override the default branch with `DEFAULT_BRANCH=my-default make update_from_cookiecutter`.
+
 ## Overcommit
 
 This project uses [overcommit](https://github.com/sds/overcommit) for

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -241,68 +241,15 @@ update_from_cookiecutter: ## Bring in changes from template project used to crea
 	bin/overcommit --uninstall
 	# cookiecutter_project_upgrader does its work in
 	# .git/cookiecutter/{{cookiecutter.project_slug}}, but RuboCop wants to inherit
-	# config from all directories above it - avoid config
-	# mismatches by moving this out of the way
+	# config from all directories above it - avoid config mismatches by moving this
+	# out of the way
 	mv .rubocop.yml .rubocop-renamed.yml || true
 	cookiecutter_project_upgrader --help >/dev/null
-	@mkdir -p .make
-	@if [ -f docs/cookiecutter_input.json ]; then \
-	  jq 'del(._output_dir, ._repo_dir, ._checkout)' docs/cookiecutter_input.json > .make/cookiecutter_context.json; \
-	fi
-	@MAIN_REPO_ROOT=$$(dirname "$$(git rev-parse --git-common-dir)"); \
-	if [ -f "$$MAIN_REPO_ROOT/rbs_collection.yaml" ]; then \
-	  mv "$$MAIN_REPO_ROOT/rbs_collection.yaml" .make/rbs_collection.yaml.bak; \
-	  touch .make/rbs_collection_yaml_hidden; \
-	fi; \
-	if [ -f "$$MAIN_REPO_ROOT/.rubocop.yml" ]; then \
-	  mv "$$MAIN_REPO_ROOT/.rubocop.yml" .make/rubocop-main.yml.bak; \
-	  touch .make/rubocop_main_hidden; \
-	fi; \
-	if [ -f .git ] && [ ! -L .git ]; then \
-	  cp .git .make/git-worktree-pointer; \
-	  GIT_DIR=$$(git rev-parse --git-dir); \
-	  rm -f .git; \
-	  ln -s "$$GIT_DIR" .git; \
-	fi; \
-	if [ -f .make/cookiecutter_context.json ]; then \
-	  IN_COOKIECUTTER_PROJECT_UPGRADER=1 cookiecutter_project_upgrader -c .make/cookiecutter_context.json -p true || true; \
-	else \
-	  IN_COOKIECUTTER_PROJECT_UPGRADER=1 cookiecutter_project_upgrader || true; \
-	fi; \
-	if [ -f .make/git-worktree-pointer ]; then \
-	  rm -f .git; \
-	  mv .make/git-worktree-pointer .git; \
-	fi; \
-	if [ -f .make/rbs_collection_yaml_hidden ]; then \
-	  mv .make/rbs_collection.yaml.bak "$$MAIN_REPO_ROOT/rbs_collection.yaml"; \
-	  rm -f .make/rbs_collection_yaml_hidden; \
-	fi; \
-	if [ -f .make/rubocop_main_hidden ]; then \
-	  mv .make/rubocop-main.yml.bak "$$MAIN_REPO_ROOT/.rubocop.yml"; \
-	  rm -f .make/rubocop_main_hidden; \
-	fi
+	bin/cookiecutter_project_upgrader_with_worktree_shim.sh
 	mv .rubocop-renamed.yml .rubocop.yml
-	@if ! git diff --quiet -- Makefile 2>/dev/null || ! git diff --cached --quiet -- Makefile 2>/dev/null; then \
-	  git stash push -m 'update_from_cookiecutter Makefile' -- Makefile; \
-	  touch .make/cookiecutter_makefile_stashed; \
-	fi
-	git checkout cookiecutter-template && git push --no-verify
-	git checkout main; overcommit --sign && overcommit --sign pre-commit && overcommit --sign pre-push && git checkout main && git pull && git checkout -b update-from-cookiecutter-$$(date +%Y-%m-%d-%H%M)
-	git merge cookiecutter-template || true
-	git checkout --ours Gemfile.lock || true
-	@if [ -f .make/cookiecutter_makefile_stashed ]; then \
-	  git stash pop; \
-	  rm -f .make/cookiecutter_makefile_stashed; \
-	fi
+	bin/update_from_cookiecutter_finish.sh
 	git checkout --theirs sorbet/rbi/gems || true
 	# update frequently security-flagged gems while we're here
 	bundle update --conservative json nokogiri rack rexml yard brakeman || true
 	( make build && git add Gemfile.lock ) || true
 	bin/spoom srb bump || true
-	bin/overcommit --install || true
-	@echo
-	@echo "Please resolve any merge conflicts below and push up a PR with:"
-	@echo
-	@echo '   gh pr create --title "Update from cookiecutter" --body "Automated PR to update from cookiecutter boilerplate"'
-	@echo
-	@echo

--- a/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader_with_worktree_shim.sh
+++ b/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader_with_worktree_shim.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Run cookiecutter_project_upgrader from the repo root, including linked git worktrees.
+#
+# cookiecutter_project_upgrader writes under $PWD/.git/cookiecutter/. In a linked
+# worktree, .git is a gitdir: pointer file, not a directory — temporarily symlink .git
+# to $(git rev-parse --git-dir) so os.path.join(..., ".git", "cookiecutter") works.
+#
+# RuboCop can inherit config from MAIN_REPO_ROOT when regenerating under .git/cookiecutter/;
+# optionally hide rbs_collection.yaml and .rubocop.yml there during the run.
+
+set -euo pipefail
+
+MAIN_REPO_ROOT="$(dirname "$(git rev-parse --git-common-dir)")"
+GIT_DIR_PATH="$(git rev-parse --git-dir)"
+MAKE_DIR=".make"
+
+RBS_HIDDEN=0
+RUBOCOP_MAIN_HIDDEN=0
+GIT_WORKTREE_SHIM=0
+
+cleanup() {
+  if [ "${GIT_WORKTREE_SHIM}" -eq 1 ] && [ -f "${MAKE_DIR}/git-worktree-pointer" ]; then
+    rm -f .git
+    mv "${MAKE_DIR}/git-worktree-pointer" .git
+    GIT_WORKTREE_SHIM=0
+  fi
+  if [ "${RBS_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rbs_collection.yaml.bak" ]; then
+    mv "${MAKE_DIR}/rbs_collection.yaml.bak" "${MAIN_REPO_ROOT}/rbs_collection.yaml"
+    rm -f "${MAKE_DIR}/rbs_collection_yaml_hidden"
+    RBS_HIDDEN=0
+  fi
+  if [ "${RUBOCOP_MAIN_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rubocop-main.yml.bak" ]; then
+    mv "${MAKE_DIR}/rubocop-main.yml.bak" "${MAIN_REPO_ROOT}/.rubocop.yml"
+    rm -f "${MAKE_DIR}/rubocop_main_hidden"
+    RUBOCOP_MAIN_HIDDEN=0
+  fi
+  if [ -d "${GIT_DIR_PATH}/cookiecutter" ]; then
+    rm -rf "${GIT_DIR_PATH}/cookiecutter"
+  fi
+}
+
+trap cleanup EXIT
+
+mkdir -p "${MAKE_DIR}"
+
+if [ -f docs/cookiecutter_input.json ]; then
+  jq 'del(._output_dir, ._repo_dir, ._checkout)' docs/cookiecutter_input.json \
+    > "${MAKE_DIR}/cookiecutter_context.json"
+fi
+
+if [ -f "${MAIN_REPO_ROOT}/rbs_collection.yaml" ]; then
+  mv "${MAIN_REPO_ROOT}/rbs_collection.yaml" "${MAKE_DIR}/rbs_collection.yaml.bak"
+  touch "${MAKE_DIR}/rbs_collection_yaml_hidden"
+  RBS_HIDDEN=1
+fi
+if [ -f "${MAIN_REPO_ROOT}/.rubocop.yml" ]; then
+  mv "${MAIN_REPO_ROOT}/.rubocop.yml" "${MAKE_DIR}/rubocop-main.yml.bak"
+  touch "${MAKE_DIR}/rubocop_main_hidden"
+  RUBOCOP_MAIN_HIDDEN=1
+fi
+
+if [ -f .make/git-worktree-pointer ] && [ ! -f .git ] && [ ! -L .git ]; then
+  echo "error: stale ${MAKE_DIR}/git-worktree-pointer but .git is missing; restore manually" >&2
+  exit 1
+fi
+
+if [ -f .git ] && [ ! -L .git ] && grep -q '^gitdir: ' .git; then
+  cp .git "${MAKE_DIR}/git-worktree-pointer"
+  rm -f .git
+  ln -s "${GIT_DIR_PATH}" .git
+  GIT_WORKTREE_SHIM=1
+elif [ -f .git ] && [ ! -L .git ]; then
+  echo "error: .git is a regular file but not a linked-worktree gitdir pointer" >&2
+  exit 1
+fi
+
+export IN_COOKIECUTTER_PROJECT_UPGRADER=1
+upgrader_status=0
+if [ -f "${MAKE_DIR}/cookiecutter_context.json" ]; then
+  cookiecutter_project_upgrader -c "${MAKE_DIR}/cookiecutter_context.json" -p true || upgrader_status=$?
+else
+  cookiecutter_project_upgrader || upgrader_status=$?
+fi
+trap - EXIT
+cleanup
+exit "${upgrader_status}"

--- a/{{cookiecutter.project_slug}}/bin/test_git_worktree_upgrader_shim.sh
+++ b/{{cookiecutter.project_slug}}/bin/test_git_worktree_upgrader_shim.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Regression test: linked-worktree .git pointer prepare/restore for cookiecutter paths.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SHIM="${ROOT}/bin/cookiecutter_project_upgrader_with_worktree_shim.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+cd "${TMP}"
+git init -q
+echo x > README.md
+git add README.md
+git commit -qm init
+git branch feat
+git worktree add wt feat -q
+
+WT="${TMP}/wt"
+POINTER="${WT}/.git"
+
+if [ ! -f "${POINTER}" ] || ! grep -q '^gitdir: ' "${POINTER}"; then
+  echo "fail: expected gitdir pointer at ${POINTER}" >&2
+  exit 1
+fi
+
+GIT_DIR="$(git -C "${WT}" rev-parse --git-dir)"
+BACKUP="${WT}/.make/git-worktree-pointer-test"
+
+mkdir -p "${WT}/.make"
+cp "${POINTER}" "${BACKUP}"
+rm -f "${POINTER}"
+ln -s "${GIT_DIR}" "${POINTER}"
+
+COOKIECUTTER_DIR="${WT}/.git/cookiecutter/nested"
+if ! mkdir -p "${COOKIECUTTER_DIR}"; then
+  echo "fail: could not mkdir under symlinked .git" >&2
+  exit 1
+fi
+
+rm -f "${POINTER}"
+mv "${BACKUP}" "${POINTER}"
+
+if ! grep -q '^gitdir: ' "${POINTER}"; then
+  echo "fail: .git pointer not restored" >&2
+  exit 1
+fi
+
+if [ -d "${COOKIECUTTER_DIR}" ]; then
+  echo "fail: temp cookiecutter dir should not survive restore" >&2
+  exit 1
+fi
+
+if [ ! -x "${SHIM}" ]; then
+  echo "fail: shim not executable: ${SHIM}" >&2
+  exit 1
+fi
+
+echo "ok: git worktree upgrader shim paths"

--- a/{{cookiecutter.project_slug}}/bin/update_from_cookiecutter_finish.sh
+++ b/{{cookiecutter.project_slug}}/bin/update_from_cookiecutter_finish.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Finish phase for make update_from_cookiecutter — safe from linked git worktrees.
+#
+# Does not checkout main or cookiecutter-template (those branches may be checked
+# out in another worktree). Uses ref-based push, fetch, switch -c, and merge.
+
+set -euo pipefail
+
+MAKE_DIR=".make"
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+
+if git symbolic-ref -q "refs/remotes/origin/HEAD" >/dev/null 2>&1; then
+  DEFAULT_BRANCH="$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')"
+fi
+
+mkdir -p "${MAKE_DIR}"
+
+if ! git diff --quiet -- Makefile 2>/dev/null || ! git diff --cached --quiet -- Makefile 2>/dev/null; then
+  git stash push -m 'update_from_cookiecutter Makefile' -- Makefile
+  touch "${MAKE_DIR}/cookiecutter_makefile_stashed"
+fi
+
+# Upgrader with -p true already pushed; re-push without checking out the branch.
+git push --no-verify origin cookiecutter-template || true
+
+git fetch "origin" "${DEFAULT_BRANCH}"
+UPDATE_BRANCH="update-from-cookiecutter-$(date +%Y-%m-%d-%H%M)"
+git switch -c "${UPDATE_BRANCH}" "origin/${DEFAULT_BRANCH}"
+echo "Created branch ${UPDATE_BRANCH} from origin/${DEFAULT_BRANCH}"
+
+bin/overcommit --sign
+bin/overcommit --sign pre-commit
+bin/overcommit --sign pre-push
+
+git merge cookiecutter-template || true
+git checkout --ours Gemfile.lock || true
+
+if [ -f "${MAKE_DIR}/cookiecutter_makefile_stashed" ]; then
+  git stash pop || true
+  rm -f "${MAKE_DIR}/cookiecutter_makefile_stashed"
+fi
+
+bundle update --conservative json rexml || true
+( make build && git add Gemfile.lock ) || true
+bin/overcommit --install || true
+
+echo
+echo "Please resolve any merge conflicts below and push up a PR with:"
+echo
+echo '   gh pr create --title "Update from cookiecutter" --body "Automated PR to update from cookiecutter boilerplate"'
+echo


### PR DESCRIPTION
## Summary

- Extract `bin/cookiecutter_project_upgrader_with_worktree_shim.sh` (linked-worktree `.git` symlink, trap cleanup, fail-closed upgrader) and `bin/update_from_cookiecutter_finish.sh` (ref-based push/fetch/switch/merge ��� no checkout of `main` or `cookiecutter-template` locked in other worktrees).
- Slim `make update_from_cookiecutter` to call those scripts; nested gem template keeps Ruby-only steps (RuboCop rename, spoom, extra bundle updates).
- Document worktree usage in `DEVELOPMENT.md` and run `make test-worktree-upgrader-shim` in CircleCI citest.

## Test plan

- [x] `bin/test_git_worktree_upgrader_shim.sh` locally
- [ ] CircleCI citest (includes shim + bake tests)

Made with [Cursor](https://cursor.com)