### PR TITLE
Add template rules for CI-first typecheck debugging

### DIFF
--- a/{{cookiecutter.project_slug}}/.cursor/rules/ci-failure-feedback-loop.mdc
+++ b/{{cookiecutter.project_slug}}/.cursor/rules/ci-failure-feedback-loop.mdc
@@ -1,0 +1,15 @@
+---
+description: On failed CircleCI checks, fetch logs first and share one concrete error before broad local retries
+globs: .circleci/**,Makefile,**/*.rb,test/**/*.rb
+alwaysApply: false
+---
+
+# CI failure feedback loop
+
+When `gh pr checks` shows a failed CircleCI check:
+
+1. Fetch the failing step logs first (prefer MCP `user-circleci-mcp-server`).
+2. Share one exact failing error line with the user before broad local retries.
+3. Fix from that error message, then push and re-watch checks.
+
+Avoid long local loops (`make citest`, full quality/build) before reading remote failure text.

--- a/{{cookiecutter.project_slug}}/.cursor/rules/typecheck-test-fixes.mdc
+++ b/{{cookiecutter.project_slug}}/.cursor/rules/typecheck-test-fixes.mdc
@@ -1,0 +1,14 @@
+---
+description: Typecheck-fix tests should satisfy Sorbet, RuboCop, and coverage/undercover gates together
+globs: lib/**/*.rb,test/**/*.rb,.overcommit.yml,rakelib/**,sorbet/**
+alwaysApply: false
+---
+
+# Typecheck fix tests
+
+When typechecking work adds or edits tests:
+
+- Run the same CI gates locally where possible (`make citypecheck`, tests, coverage/undercover gate).
+- In `# typed: true` tests, use explicit typed locals when blocks mutate values (for example `T.let(false, T::Boolean)`).
+- Run RuboCop on new tests before push (Minitest cops often fail on small formatting details).
+- If a utility method changed in `lib/`, add targeted unit tests so coverage/undercover does not fail on the same diff.

--- a/{{cookiecutter.project_slug}}/.cursor/rules/typecheck-test-fixes.mdc
+++ b/{{cookiecutter.project_slug}}/.cursor/rules/typecheck-test-fixes.mdc
@@ -1,14 +1,20 @@
 ---
-description: Typecheck-fix tests should satisfy Sorbet, RuboCop, and coverage/undercover gates together
+description: Gradual typing fixes — Sorbet block locals, tests, RuboCop, and undercover gates
 globs: lib/**/*.rb,test/**/*.rb,.overcommit.yml,rakelib/**,sorbet/**
 alwaysApply: false
 ---
 
-# Typecheck fix tests
+# Typecheck fixes (Sorbet + CI gates)
 
-When typechecking work adds or edits tests:
+## Sorbet: locals mutated inside blocks
+
+When Sorbet typechecks a file in `lib/` or `test/` and a local is updated inside a block (callback, `yield`, etc.), initialize with an explicit type if literals would narrow too far—e.g. `flag = T.let(false, T::Boolean)` before assigning `true` in the block.
+
+## Tests and CI
+
+When typechecking work adds or edits code:
 
 - Run the same CI gates locally where possible (`make citypecheck`, tests, coverage/undercover gate).
-- In `# typed: true` tests, use explicit typed locals when blocks mutate values (for example `T.let(false, T::Boolean)`).
+- Apply the block-local rule when callbacks/blocks flip flags or similar.
 - Run RuboCop on new tests before push (Minitest cops often fail on small formatting details).
-- If a utility method changed in `lib/`, add targeted unit tests so coverage/undercover does not fail on the same diff.
+- New or changed instance methods under `lib/` need coverage in `test/unit/` for undercover.

--- a/{{cookiecutter.project_slug}}/.cursor/skills/solargraph-typecheck/SKILL.md
+++ b/{{cookiecutter.project_slug}}/.cursor/skills/solargraph-typecheck/SKILL.md
@@ -140,6 +140,10 @@ Scripts under `script/` should be **typed** (`# typed: true`) when typechecked:
 - Document all methods with `@param` / `@return`.
 - Avoid `@sg-ignore` in comments that are not actual directives.
 
+## Sorbet: locals mutated inside blocks
+
+When Sorbet reports **Changing the type of a variable is not permitted in loops and blocks** on a local updated inside a block (callback, `yield`, etc.), initialize with an explicit type—e.g. `flag = T.let(false, T::Boolean)` before `flag = true` in the block.
+
 ## Rubocop fallout
 
 After adding many `# @return [void]` lines in tests (historical) or editing scripts:


### PR DESCRIPTION
## Summary

Nested `{{cookiecutter.project_slug}}/` template rules for typecheck/CI workflows:

- **ci-failure-feedback-loop:** fetch CircleCI logs first; share one concrete error line before broad local retries.
- **typecheck-test-fixes:** Sorbet block-local `T.let` in `lib/` or `test/`; CI gates and RuboCop on new tests; undercover coverage for new/changed methods under `lib/`.
- **solargraph-typecheck skill:** documents the Sorbet ���changing type in loops and blocks��� fix alongside Solargraph work.

All rules use `alwaysApply: false` and focused globs.

## Test plan

- [ ] CI green on this branch
- [ ] Baked project rules appear under `.cursor/rules/` after cookiecutter generate