### PR TITLE
Add RegenerateTypecheck hook for Gemfile.lock changes

### DIFF
--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -55,11 +55,12 @@ commands:
       - restore_cache:
           name: Restore ruby-types cache
           keys:
-            - ruby-types-v3-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-{% raw %}{{ checksum ".circleci/config.yml" }}{% endraw %}-
-            - ruby-types-v3-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-
-            - ruby-types-v3-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-
-            - ruby-types-v3-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-
-            - ruby-types-v3-
+            - ruby-types-v4-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "rbs_collection.lock.yaml" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-{% raw %}{{ checksum ".circleci/config.yml" }}{% endraw %}-
+            - ruby-types-v4-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-{% raw %}{{ checksum ".circleci/config.yml" }}{% endraw %}-
+            - ruby-types-v4-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-
+            - ruby-types-v4-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-
+            - ruby-types-v4-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-
+            - ruby-types-v4-
       - restore_cache:
           name: Restore pyenv cache
           keys:
@@ -244,7 +245,7 @@ jobs:
           path: rbi/{{cookiecutter.project_slug}}.rbi
       - save_cache:
           name: 'Save ruby-types cache'
-          key: ruby-types-v3-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-{% raw %}{{ checksum ".circleci/config.yml" }}{% endraw %}-{% raw %}{{ checksum ".ruby-version" }}{% endraw %}-{% raw %}{{ checksum {% endraw %}"rbi/{{cookiecutter.project_slug}}.rbi" {% raw %}}}{% endraw %}  # yamllint disable-line rule:line-length
+          key: ruby-types-v4-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "rbs_collection.lock.yaml" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-{% raw %}{{ checksum ".circleci/config.yml" }}{% endraw %}-{% raw %}{{ checksum ".ruby-version" }}{% endraw %}-{% raw %}{{ checksum {% endraw %}"rbi/{{cookiecutter.project_slug}}.rbi" {% raw %}}}{% endraw %}  # yamllint disable-line rule:line-length
           paths:
             - ".yardoc"
             - 'yarddoc'

--- a/{{cookiecutter.project_slug}}/.cursor/rules/typecheck-rbi-and-ci.mdc
+++ b/{{cookiecutter.project_slug}}/.cursor/rules/typecheck-rbi-and-ci.mdc
@@ -19,6 +19,7 @@ alwaysApply: false
 - **Do not** manually remove or cherry-pick files under `sorbet/rbi/gems/` (e.g. `git rm` duplicate `parlour@*.rbi` files).
 - Those artifacts are produced and refreshed by **`make build-typecheck`** (tapioca, `rbs collection`, and related Makefile targets).
 - If Sorbet reports duplicate or stale gem RBIs, run **`make build-typecheck`** (or **`make ci-build-typecheck`** where defined), fix lockfiles/generators/CI cache as needed, and commit what the Makefile regenerates—not a hand-edited RBI tree.
+- When **`Gemfile.lock`** is in the commit, Overcommit **`RegenerateTypecheck`** (`.git-hooks/pre_commit/regenerate_typecheck.rb`) runs **`make build-typecheck`** and stages regenerated RBI/RBS paths before push.
 
 ## Local vs CI typechecking
 

--- a/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/regenerate_typecheck.rb
+++ b/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/regenerate_typecheck.rb
@@ -1,0 +1,44 @@
+# typed: true
+# frozen_string_literal: true
+
+require 'overcommit'
+require 'overcommit/hook/pre_commit/base'
+
+module Overcommit
+  module Hook
+    module PreCommit
+      # Regenerates typechecking artifacts when Gemfile.lock is committed.
+      class RegenerateTypecheck < Base
+        # Tracked paths updated by `make build-typecheck` (see Makefile).
+        BUILD_TYPECHECK_PATHS = [
+          'sorbet/rbi/gems',
+          'sorbet/rbi/annotations',
+          'sorbet/rbi/dsl',
+          'sorbet/rbi/todo.rbi',
+          'rbs_collection.lock.yaml',
+          'rbi',
+        ].freeze
+
+        STAMP_FILES = %w[
+          tapioca.installed
+          Gemfile.lock.installed
+          types.installed
+        ].freeze
+
+        # @return [Symbol, Array<Symbol, String>]
+        def run
+          execute(['rm', '-f', *STAMP_FILES])
+          # @type [Overcommit::Subprocess::Result]
+          result = execute(%w[make build-typecheck])
+          return [:fail, result.stdout + result.stderr] unless result.success?
+
+          # @type [Overcommit::Subprocess::Result]
+          stage_result = execute(['git', 'add', '-A', '--', *BUILD_TYPECHECK_PATHS])
+          return :pass if stage_result.success?
+
+          [:fail, stage_result.stdout + stage_result.stderr]
+        end
+      end
+    end
+  end
+end

--- a/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/regenerate_typecheck.rb
+++ b/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/regenerate_typecheck.rb
@@ -32,8 +32,11 @@ module Overcommit
           result = execute(%w[make build-typecheck])
           return [:fail, result.stdout + result.stderr] unless result.success?
 
+          paths_to_stage = BUILD_TYPECHECK_PATHS.select { |path| File.exist?(path) }
+          return :pass if paths_to_stage.empty?
+
           # @type [Overcommit::Subprocess::Result]
-          stage_result = execute(['git', 'add', '-A', '--', *BUILD_TYPECHECK_PATHS])
+          stage_result = execute(['git', 'add', '-A', '--', *paths_to_stage])
           return :pass if stage_result.success?
 
           [:fail, stage_result.stdout + stage_result.stderr]


### PR DESCRIPTION
## Summary
- Add `.git-hooks/pre_commit/regenerate_typecheck.rb` for baked `{{cookiecutter.project_slug}}/` projects (Overcommit already had `RegenerateTypecheck` in `.overcommit.yml` without the plugin file).
- Pre-commit runs `make build-typecheck` when `Gemfile.lock` is in the commit and stages regenerated `sorbet/rbi/*`, `rbs_collection.lock.yaml`, and `rbi/` paths.
- Document the hook in `typecheck-rbi-and-ci.mdc`.

## Test plan
- [ ] In a generated Ruby project: stage `Gemfile.lock`, run `bin/overcommit --run RegenerateTypecheck` or commit; confirm `make build-typecheck` runs and gem RBIs are staged.

Made with [Cursor](https://cursor.com)