### PR TITLE
Cursor rule: CIRCLECI env in fix.sh is a smell

### DIFF
--- a/.cursor/rules/circleci-env-in-fix-sh.mdc
+++ b/.cursor/rules/circleci-env-in-fix-sh.mdc
@@ -1,0 +1,40 @@
+---
+description: >-
+  Treat CIRCLECI (or CI) env branching in fix.sh and bootstrap scripts as a smell —
+  fix belongs in CircleCI config, Makefile targets, or hooks, not shell CI detection
+globs:
+  - "fix.sh"
+  - "bin/**"
+  - ".githooks/**"
+alwaysApply: false
+---
+
+# CIRCLECI env checks in fix.sh (smell)
+
+## Rule
+
+Do **not** add or extend `if [ -n "${CIRCLECI:-}" ]` (or similar) in `fix.sh`, `bin/*`, or git hooks to change install behavior, skip steps, or paper over CI-only failures.
+
+That pattern usually means:
+
+- The **wrong layer** is owning the behavior (bootstrap script vs CI job vs Makefile).
+- The **root cause** in CircleCI (cache, image, checkout, env) was not fixed.
+- Local and CI paths **diverge**, so regressions hide until push.
+
+## Do instead
+
+| Need | Put it here |
+|------|-------------|
+| CI-only setup or retries | `.circleci/config.yml` job `steps` |
+| Optional slow work | Makefile target; CI calls that target explicitly |
+| Post-checkout bootstrap | `fix.sh` / `bin/git-post-checkout-fix` for **all** environments equally |
+| Document a one-off CI quirk | Comment linking the **CircleCI job URL** plus the real fix; remove when CI is corrected |
+
+## Allowed exceptions
+
+- Reading `CIRCLECI` only to **print** diagnostics (no behavior change).
+- Upstream boilerplate you are **removing** in the same PR as part of a CI fix.
+
+## Agents
+
+When reviewing bootstrap changes, prefer deleting CI branches and fixing CircleCI or Makefile. Use `circleci-logs-before-local-ci.mdc` when CI failed before editing `fix.sh`.

--- a/.cursor/rules/template-hierarchy.mdc
+++ b/.cursor/rules/template-hierarchy.mdc
@@ -16,6 +16,7 @@ Cookiecutter templates in this family stack **general → specific** (meta → l
 |----------------|---------------|---------------|----------------------------------------------------------------|
 | `overcommit-signing.mdc` | Yes | Yes | Yes |
 | `circleci-logs-before-local-ci.mdc` | No | Yes (cookiecutter maintenance) | **Yes** — baked Ruby gems/apps |
+| `circleci-env-in-fix-sh.mdc` | No | Yes | **Yes** — baked Ruby gems/apps |
 | `typecheck-rbi-and-ci.mdc` | No | No | **Yes** — baked Ruby gems/apps only |
 | `template-hierarchy.mdc` | Yes | Yes (this file) | No |
 | `fix.sh`, `bin/git-*` hooks, `.githooks/post-checkout`, shared `.overcommit.yml` bootstrap | Yes | Yes | Yes |

--- a/{{cookiecutter.project_slug}}/.cursor/rules/circleci-env-in-fix-sh.mdc
+++ b/{{cookiecutter.project_slug}}/.cursor/rules/circleci-env-in-fix-sh.mdc
@@ -1,0 +1,40 @@
+---
+description: >-
+  Treat CIRCLECI (or CI) env branching in fix.sh and bootstrap scripts as a smell —
+  fix belongs in CircleCI config, Makefile targets, or hooks, not shell CI detection
+globs:
+  - "fix.sh"
+  - "bin/**"
+  - ".githooks/**"
+alwaysApply: false
+---
+
+# CIRCLECI env checks in fix.sh (smell)
+
+## Rule
+
+Do **not** add or extend `if [ -n "${CIRCLECI:-}" ]` (or similar) in `fix.sh`, `bin/*`, or git hooks to change install behavior, skip steps, or paper over CI-only failures.
+
+That pattern usually means:
+
+- The **wrong layer** is owning the behavior (bootstrap script vs CI job vs Makefile).
+- The **root cause** in CircleCI (cache, image, checkout, env) was not fixed.
+- Local and CI paths **diverge**, so regressions hide until push.
+
+## Do instead
+
+| Need | Put it here |
+|------|-------------|
+| CI-only setup or retries | `.circleci/config.yml` job `steps` |
+| Optional slow work | Makefile target; CI calls that target explicitly |
+| Post-checkout bootstrap | `fix.sh` / `bin/git-post-checkout-fix` for **all** environments equally |
+| Document a one-off CI quirk | Comment linking the **CircleCI job URL** plus the real fix; remove when CI is corrected |
+
+## Allowed exceptions
+
+- Reading `CIRCLECI` only to **print** diagnostics (no behavior change).
+- Upstream boilerplate you are **removing** in the same PR as part of a CI fix.
+
+## Agents
+
+When reviewing bootstrap changes, prefer deleting CI branches and fixing CircleCI or Makefile. Use `circleci-logs-before-local-ci.mdc` when CI failed before editing `fix.sh`.


### PR DESCRIPTION
## Summary
- Add circleci-env-in-fix-sh.mdc at root and nested baked-project tier.
- Discourage CIRCLECI branching in fix.sh/bin hooks (checkoff #451 review).

## Test plan
- [ ] CI green