### PR TITLE
Skip overcommit-hook when patching Cursor worktree bootstrap

### DIFF
--- a/.git-hooks/bootstrap_local_overcommit.rb
+++ b/.git-hooks/bootstrap_local_overcommit.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Link machine-local Overcommit config into Cursor worktrees and defer signature
+# verification until `overcommit --sign` has run in this worktree (via fix.sh).
+require 'yaml'
+require 'fileutils'
+
+# @param path [String]
+# @return [Hash, nil]
+def load_local_overcommit_config(path)
+  data = YAML.load_file(path)
+  data.is_a?(Hash) ? data : nil
+rescue StandardError
+  nil
+end
+
+repo_root = String(`git rev-parse --show-toplevel 2>/dev/null`).strip
+exit if repo_root.empty?
+
+local_file = File.join(repo_root, '.local-overcommit.yml')
+worktrees_prefix = File.expand_path('~/.cursor/worktrees')
+
+if !File.exist?(local_file) && repo_root.start_with?("#{worktrees_prefix}/")
+  rel = repo_root.delete_prefix("#{worktrees_prefix}/")
+  repo_name = rel.split('/').first
+  source = File.join(File.expand_path('~/src'), repo_name, '.local-overcommit.yml')
+  FileUtils.ln_sf(source, local_file) if File.exist?(source)
+end
+
+return unless File.exist?(local_file)
+
+raw_config = load_local_overcommit_config(local_file)
+return unless raw_config&.[]('verify_signatures') == false
+
+signed = String(`git config --local --get overcommit.configuration.verifysignatures 2>/dev/null`).strip
+ENV['OVERCOMMIT_NO_VERIFY'] = '1' if signed != '0'

--- a/.git-hooks/bootstrap_local_overcommit.rb
+++ b/.git-hooks/bootstrap_local_overcommit.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 # Link machine-local Overcommit config into Cursor worktrees and defer signature
@@ -24,6 +25,7 @@ if !File.exist?(local_file) && repo_root.start_with?("#{worktrees_prefix}/")
   rel = repo_root.delete_prefix("#{worktrees_prefix}/")
   repo_name = rel.split('/').first
   source = File.join(File.expand_path('~/src'), repo_name, '.local-overcommit.yml')
+  # @sg-ignore FileUtils.ln_sf src path typing in bootstrap hook
   FileUtils.ln_sf(source, local_file) if File.exist?(source)
 end
 
@@ -33,4 +35,5 @@ raw_config = load_local_overcommit_config(local_file)
 return unless raw_config&.[]('verify_signatures') == false
 
 signed = String(`git config --local --get overcommit.configuration.verifysignatures 2>/dev/null`).strip
+# @sg-ignore ENV[]= not resolved on ENV class in Solargraph
 ENV['OVERCOMMIT_NO_VERIFY'] = '1' if signed != '0'

--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,9 @@ types.installed
 # 1Password Environment local mount (resolved literals; template is config/env.1p)
 /config/env.local
 
+# Local Overcommit overrides (verify_signatures, etc.)
+.local-overcommit.yml
+
 # Overcommit installs hooks here; only bootstrap post-checkout is tracked
 .githooks/*
 !.githooks/post-checkout

--- a/fix.sh
+++ b/fix.sh
@@ -429,6 +429,34 @@ EOF
   chmod +x .githooks/post-checkout
 }
 
+patch_overcommit_hooks() {
+  # Inject bootstrap so Cursor worktrees inherit .local-overcommit.yml before
+  # Overcommit loads config (gitignored file is absent on fresh worktree checkout).
+  # Do NOT patch overcommit-hook: it must match the gem template or Overcommit
+  # self-update will reinstall all hooks and strip these patches.
+  local hook hooks_dir bootstrap_line
+  hooks_dir="$(git config --get core.hooksPath 2>/dev/null || echo .git/hooks)"
+  bootstrap_line="repo_root = String(\`git rev-parse --show-toplevel 2>/dev/null\`).strip; load File.join(repo_root, '.git-hooks', 'bootstrap_local_overcommit.rb') rescue nil if repo_root != '' # OVERCOMMIT_REPO_BOOTSTRAP"
+
+  for hook in "${hooks_dir}"/*
+  do
+    [ -f "$hook" ] || continue
+    [[ "$(basename "$hook")" == "overcommit-hook" ]] && continue
+    grep -q 'OVERCOMMIT_REPO_BOOTSTRAP' "$hook" && continue
+    grep -q 'Entrypoint for Overcommit hook integration' "$hook" || continue
+    ruby - "$hook" "$bootstrap_line" <<'RUBY'
+hook_path = ARGV[0]
+bootstrap_line = ARGV[1]
+contents = File.read(hook_path)
+marker = "if ENV['OVERCOMMIT_DISABLE'].to_i != 0 || ENV['OVERCOMMIT_DISABLED'].to_i != 0\n  exit\nend\n"
+unless contents.include?('OVERCOMMIT_REPO_BOOTSTRAP')
+  raise "bootstrap insertion point not found in #{hook_path}" unless contents.include?(marker)
+  File.write(hook_path, contents.sub(marker, "#{marker}\n#{bootstrap_line}\n"))
+end
+RUBY
+  done
+}
+
 ensure_overcommit() {
   # don't run if we're in the middle of a cookiecutter child project
   # test, or otherwise don't have a Git repo to install hooks into...
@@ -437,6 +465,7 @@ ensure_overcommit() {
     bundle exec overcommit --install
     bundle exec overcommit --sign
     bundle exec overcommit --sign pre-commit
+    patch_overcommit_hooks
     install_bootstrap_post_checkout_hook
   else
     >&2 echo 'Not in a git repo; not installing git hooks'

--- a/{{cookiecutter.project_slug}}/.git-hooks/bootstrap_local_overcommit.rb
+++ b/{{cookiecutter.project_slug}}/.git-hooks/bootstrap_local_overcommit.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Link machine-local Overcommit config into Cursor worktrees and defer signature
+# verification until `overcommit --sign` has run in this worktree (via fix.sh).
+require 'yaml'
+require 'fileutils'
+
+# @param path [String]
+# @return [Hash, nil]
+def load_local_overcommit_config(path)
+  data = YAML.load_file(path)
+  data.is_a?(Hash) ? data : nil
+rescue StandardError
+  nil
+end
+
+repo_root = String(`git rev-parse --show-toplevel 2>/dev/null`).strip
+exit if repo_root.empty?
+
+local_file = File.join(repo_root, '.local-overcommit.yml')
+worktrees_prefix = File.expand_path('~/.cursor/worktrees')
+
+if !File.exist?(local_file) && repo_root.start_with?("#{worktrees_prefix}/")
+  rel = repo_root.delete_prefix("#{worktrees_prefix}/")
+  repo_name = rel.split('/').first
+  source = File.join(File.expand_path('~/src'), repo_name, '.local-overcommit.yml')
+  FileUtils.ln_sf(source, local_file) if File.exist?(source)
+end
+
+return unless File.exist?(local_file)
+
+raw_config = load_local_overcommit_config(local_file)
+return unless raw_config&.[]('verify_signatures') == false
+
+signed = String(`git config --local --get overcommit.configuration.verifysignatures 2>/dev/null`).strip
+ENV['OVERCOMMIT_NO_VERIFY'] = '1' if signed != '0'

--- a/{{cookiecutter.project_slug}}/.git-hooks/bootstrap_local_overcommit.rb
+++ b/{{cookiecutter.project_slug}}/.git-hooks/bootstrap_local_overcommit.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 # Link machine-local Overcommit config into Cursor worktrees and defer signature
@@ -24,6 +25,7 @@ if !File.exist?(local_file) && repo_root.start_with?("#{worktrees_prefix}/")
   rel = repo_root.delete_prefix("#{worktrees_prefix}/")
   repo_name = rel.split('/').first
   source = File.join(File.expand_path('~/src'), repo_name, '.local-overcommit.yml')
+  # @sg-ignore FileUtils.ln_sf src path typing in bootstrap hook
   FileUtils.ln_sf(source, local_file) if File.exist?(source)
 end
 
@@ -33,4 +35,5 @@ raw_config = load_local_overcommit_config(local_file)
 return unless raw_config&.[]('verify_signatures') == false
 
 signed = String(`git config --local --get overcommit.configuration.verifysignatures 2>/dev/null`).strip
+# @sg-ignore ENV[]= not resolved on ENV class in Solargraph
 ENV['OVERCOMMIT_NO_VERIFY'] = '1' if signed != '0'

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -71,6 +71,9 @@ sorbet/machine_specific_config
 # 1Password Environment local mount (resolved literals; template is config/env.1p)
 /config/env.local
 
+# Local Overcommit overrides (verify_signatures, etc.)
+.local-overcommit.yml
+
 # Overcommit installs hooks here; only bootstrap post-checkout is tracked
 .githooks/*
 !.githooks/post-checkout

--- a/{{cookiecutter.project_slug}}/fix.sh
+++ b/{{cookiecutter.project_slug}}/fix.sh
@@ -429,6 +429,34 @@ EOF
   chmod +x .githooks/post-checkout
 }
 
+patch_overcommit_hooks() {
+  # Inject bootstrap so Cursor worktrees inherit .local-overcommit.yml before
+  # Overcommit loads config (gitignored file is absent on fresh worktree checkout).
+  # Do NOT patch overcommit-hook: it must match the gem template or Overcommit
+  # self-update will reinstall all hooks and strip these patches.
+  local hook hooks_dir bootstrap_line
+  hooks_dir="$(git config --get core.hooksPath 2>/dev/null || echo .git/hooks)"
+  bootstrap_line="repo_root = String(\`git rev-parse --show-toplevel 2>/dev/null\`).strip; load File.join(repo_root, '.git-hooks', 'bootstrap_local_overcommit.rb') rescue nil if repo_root != '' # OVERCOMMIT_REPO_BOOTSTRAP"
+
+  for hook in "${hooks_dir}"/*
+  do
+    [ -f "$hook" ] || continue
+    [[ "$(basename "$hook")" == "overcommit-hook" ]] && continue
+    grep -q 'OVERCOMMIT_REPO_BOOTSTRAP' "$hook" && continue
+    grep -q 'Entrypoint for Overcommit hook integration' "$hook" || continue
+    ruby - "$hook" "$bootstrap_line" <<'RUBY'
+hook_path = ARGV[0]
+bootstrap_line = ARGV[1]
+contents = File.read(hook_path)
+marker = "if ENV['OVERCOMMIT_DISABLE'].to_i != 0 || ENV['OVERCOMMIT_DISABLED'].to_i != 0\n  exit\nend\n"
+unless contents.include?('OVERCOMMIT_REPO_BOOTSTRAP')
+  raise "bootstrap insertion point not found in #{hook_path}" unless contents.include?(marker)
+  File.write(hook_path, contents.sub(marker, "#{marker}\n#{bootstrap_line}\n"))
+end
+RUBY
+  done
+}
+
 ensure_overcommit() {
   # don't run if we're in the middle of a cookiecutter child project
   # test, or otherwise don't have a Git repo to install hooks into...
@@ -437,6 +465,7 @@ ensure_overcommit() {
     bundle exec overcommit --install
     bundle exec overcommit --sign
     bundle exec overcommit --sign pre-commit
+    patch_overcommit_hooks
     install_bootstrap_post_checkout_hook
   else
     >&2 echo 'Not in a git repo; not installing git hooks'


### PR DESCRIPTION
## Summary
- Port worktree-local Overcommit bootstrap (`.local-overcommit.yml` + `bootstrap_local_overcommit.rb`) to the template at root and nested `{{cookiecutter.project_slug}}/`.
- `patch_overcommit_hooks` injects bootstrap after `overcommit --install` but skips `overcommit-hook` so Overcommit self-update does not reinstall hooks and strip patches.
- Hook patching uses `core.hooksPath` (`.githooks/`) and `git rev-parse` for bootstrap load so layouts differ from `.git/hooks` baked apps.

## Test plan
- [ ] `./fix.sh` in cookiecutter-ruby checkout
- [ ] Confirm `.githooks/overcommit-hook` matches gem template; other hooks have `OVERCOMMIT_REPO_BOOTSTRAP`
- [ ] After merge, cascade downstream Ruby apps and verify Cursor worktree add succeeds back-to-back


Made with [Cursor](https://cursor.com)