### PR TITLE
Treat worktree env.local symlinks as mounted in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,7 +5,9 @@
 
 PATH_add bin
 
-if [[ -r config/env.local ]]; then
+# -L: worktree symlink to mounted env.local (FIFO; -r is false without a writer).
+# -r: regular file or FIFO with an active reader/writer.
+if [[ -L config/env.local || -r config/env.local ]]; then
   # Load from mounted Environment file (empty mount => no secrets).
   if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
     echo "config/env.local must contain resolved values, not op:// references." >&2

--- a/{{cookiecutter.project_slug}}/.envrc
+++ b/{{cookiecutter.project_slug}}/.envrc
@@ -5,7 +5,9 @@
 
 PATH_add bin
 
-if [[ -r config/env.local ]]; then
+# -L: worktree symlink to mounted env.local (FIFO; -r is false without a writer).
+# -r: regular file or FIFO with an active reader/writer.
+if [[ -L config/env.local || -r config/env.local ]]; then
   # Load from mounted Environment file (empty mount => no secrets).
   if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
     echo "config/env.local must contain resolved values, not op:// references." >&2


### PR DESCRIPTION
## Summary

- Port `cookiecutter-cookiecutter` #615 worktree symlink guard into `.envrc` at repo root and `{{cookiecutter.project_slug}}/`.
- Uses `-L config/env.local || -r config/env.local` so Cursor worktrees with a symlinked `config/env.local` load secrets correctly.
- Does **not** add `watch_file` (declined at `cookiecutter-cookiecutter`).

Reference: `cookiecutter-cookiecutter` `14b9ae4`.

## Test plan

- [x] `make test`
- [ ] CI green