### PR TITLE
Port env.local worktree probe tooling to cookiecutter-ruby

### DIFF
--- a/{{cookiecutter.project_slug}}/.cursor/rules/worktree-env-local-probe.mdc
+++ b/{{cookiecutter.project_slug}}/.cursor/rules/worktree-env-local-probe.mdc
@@ -1,0 +1,31 @@
+---
+description: >-
+  Cursor worktree bootstrap failed or env.local/op run debugging — read
+  file-based probe logs before inferring from missing direnv stderr
+alwaysApply: false
+globs:
+  - .envrc
+  - bin/probe_env_local
+  - config/env.local
+---
+
+# env.local probe logs (worktree bootstrap)
+
+`ls`/`cat` redirected to stderr in `.envrc` do **not** appear in worktree-fix bootstrap logs. Use file probes instead.
+
+## Before diagnosing bootstrap
+
+1. Read the pointer: `.env-local-probe-path` (one line: absolute log path).
+2. Read the log tail: `~/.cache/env-local-probe/<worktree-basename>.log` (e.g. `kaa0.log`).
+3. If missing or stale, run from repo root: `./bin/probe_env_local` (no direnv required).
+
+## Interpret `which_branch`
+
+| Value | Meaning |
+|-------|---------|
+| `env.local` | Symlink or readable mount present; `.envrc` should skip `op run`. |
+| `op_run` | No symlink/readable mount at eval time; falls back to `op run`. |
+
+Also check: `-L`/`-r`, `cat exit=` (124 = FIFO with no writer / Environment not mounted), `op_run_fallback` section.
+
+Every `.envrc` eval appends a block (source=`envrc`). Bootstrap retries produce multiple timestamped blocks — compare hook time to latest block.

--- a/{{cookiecutter.project_slug}}/.envrc
+++ b/{{cookiecutter.project_slug}}/.envrc
@@ -5,7 +5,16 @@
 
 PATH_add bin
 
-if [[ -r config/env.local ]]; then
+watch_file config/env.local
+watch_file config/env.1p
+
+# File probe: bootstrap hooks omit .envrc stderr; see bin/probe_env_local and
+# ~/.cache/env-local-probe/<worktree-basename>.log (also .env-local-probe-path).
+ENV_LOCAL_PROBE_SOURCE=envrc ENV_LOCAL_PROBE_QUIET=1 ./bin/probe_env_local || true
+
+# -L: worktree symlink to mounted env.local (FIFO; -r is false without a writer).
+# -r: regular file or FIFO with an active reader/writer.
+if [[ -L config/env.local || -r config/env.local ]]; then
   # Load from mounted Environment file (empty mount => no secrets).
   if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
     echo "config/env.local must contain resolved values, not op:// references." >&2
@@ -27,7 +36,8 @@ if [[ -r config/env.local ]]; then
       end
     '
   )"
-elif [[ -r config/env.1p ]] && grep -qE '^[A-Z][A-Z0-9_]*=' config/env.1p 2>/dev/null; then
+elif resolved_env_1p="$(./bin/resolve_env_1p)" && [[ -r "${resolved_env_1p}" ]] && grep -qE '^[A-Z][A-Z0-9_]*=' "${resolved_env_1p}" 2>/dev/null; then
   # Resolve op:// template when env.local is not mounted.
-  direnv_load op run --cache --env-file=config/env.1p -- direnv dump
+  ENV_1P="${resolved_env_1p}"
+  direnv_load op run --cache --env-file="${ENV_1P}" -- direnv dump
 fi

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -84,3 +84,4 @@ sorbet/machine_specific_config
 
 # Ignore 1Password-generated secrets
 /config/env
+.env-local-probe-path

--- a/{{cookiecutter.project_slug}}/bin/probe_env_local
+++ b/{{cookiecutter.project_slug}}/bin/probe_env_local
@@ -1,0 +1,67 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+# Append config/env.local readiness evidence. Bootstrap hooks omit .envrc stderr;
+# this log survives direnv/worktree-fix capture gaps.
+
+probe_log_dir="${ENV_LOCAL_PROBE_DIR:-${HOME}/.cache/env-local-probe}"
+mkdir -p "${probe_log_dir}"
+
+probe_id="${ENV_LOCAL_PROBE_ID:-$(basename "${PWD}")}"
+log_file="${probe_log_dir}/${probe_id}.log"
+
+{
+  echo "=== $(date -u +%Y-%m-%dT%H:%M:%SZ) source=${ENV_LOCAL_PROBE_SOURCE:-manual} pwd=${PWD} ==="
+  echo "git_head=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)@$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+  echo "symlink:"; ls -ld config/env.local 2>&1 || true
+  target="$(readlink config/env.local 2>/dev/null || true)"
+  echo "readlink=${target:-<none>}"
+  if [[ -n ${target} ]]; then
+    echo "target:"; ls -ld "${target}" 2>&1 || true
+  fi
+  echo "tests: -L=$([[ -L config/env.local ]] && echo yes || echo no) -r=$([[ -r config/env.local ]] && echo yes || echo no)"
+  echo "file(1):"; file config/env.local 2>&1 || true
+  if [[ -L config/env.local || -r config/env.local ]]; then
+    branch=env.local
+  else
+    branch=op_run
+  fi
+  echo "which_branch=${branch}"
+  echo "cat_sample (2s timeout, keys only):"
+  if command -v timeout >/dev/null 2>&1; then
+    set +e
+    timeout 2 cat config/env.local 2>&1 | head -20 | while IFS= read -r line; do
+      key="${line%%=*}"
+      if [[ ${key} == "${line}" ]]; then
+        echo "  ${line}"
+      else
+        echo "  ${key}=<redacted>"
+      fi
+    done
+    cat_status=${PIPESTATUS[0]}
+    set -e
+    echo "  cat exit=${cat_status} (124=timeout)"
+  else
+    echo "  (timeout command not available)"
+  fi
+  if [[ ${branch} == op_run ]]; then
+    echo "op_run_fallback:"
+    resolved="$(./bin/resolve_env_1p 2>/dev/null || echo config/env.1p)"
+    echo "  resolve_env_1p=${resolved}"
+    echo "  resolved_readable=$([[ -r ${resolved} ]] && echo yes || echo no)"
+    if command -v op >/dev/null 2>&1; then
+      echo "  op_account_list=$(op account list 2>&1 | head -3 | tr '\n' '; ' || true)"
+    else
+      echo "  op_account_list=op not in PATH"
+    fi
+  fi
+  echo
+} >>"${log_file}"
+
+printf '%s\n' "${log_file}" >"${PWD}/.env-local-probe-path" 2>/dev/null || true
+
+if [[ ${ENV_LOCAL_PROBE_QUIET:-} != 1 ]]; then
+  echo "${log_file}"
+  tail -30 "${log_file}"
+fi

--- a/{{cookiecutter.project_slug}}/bin/resolve_env_1p
+++ b/{{cookiecutter.project_slug}}/bin/resolve_env_1p
@@ -1,0 +1,24 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+# config/env.1p may be a symlink whose target is only valid from the primary worktree.
+# Resolve via the first worktree listed by git.
+
+if [[ -r config/env.1p ]]; then
+  echo config/env.1p
+  exit 0
+fi
+
+main_wt=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / { print $2; exit }')
+if [[ -n ${main_wt} && -r ${main_wt}/config/env.1p ]]; then
+  link_dir=${main_wt}/config
+  target=$(readlink "${link_dir}/env.1p")
+  resolved=${link_dir}/${target}
+  if [[ -r ${resolved} ]]; then
+    echo "${resolved}"
+    exit 0
+  fi
+fi
+
+echo config/env.1p


### PR DESCRIPTION
## Summary
- Add `bin/probe_env_local` and `bin/resolve_env_1p` under `{{cookiecutter.project_slug}}/`.
- Update nested `.envrc`: watch files, probe on eval, `-L || -r` env.local load, `resolve_env_1p` for `op run` fallback.
- Add `worktree-env-local-probe.mdc` and ignore `.env-local-probe-path`.

## Context
Cross-language probe tooling landed in `cookiecutter-cookiecutter` (https://github.com/apiology/cookiecutter-cookiecutter/pull/617). This ports the same pattern into the Ruby language template nested path.

## Test plan
- [ ] `bash -n {{cookiecutter.project_slug}}/bin/probe_env_local {{cookiecutter.project_slug}}/bin/resolve_env_1p`
- [ ] `make` / bake tests in `cookiecutter-ruby`