### PR TITLE
Link local Overcommit config from sibling git worktrees

### DIFF
--- a/.git-hooks/bootstrap_local_overcommit.rb
+++ b/.git-hooks/bootstrap_local_overcommit.rb
@@ -37,6 +37,7 @@ local_file = File.join(repo_root, '.local-overcommit.yml')
 
 unless File.exist?(local_file)
   source = sibling_worktree_local_overcommit(repo_root)
+  # @sg-ignore FileUtils.ln_sf src path typing in bootstrap hook
   FileUtils.ln_sf(source, local_file) if source
 end
 

--- a/.git-hooks/bootstrap_local_overcommit.rb
+++ b/.git-hooks/bootstrap_local_overcommit.rb
@@ -1,7 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
-# Link machine-local Overcommit config into Cursor worktrees and defer signature
+# Link machine-local Overcommit config across git worktrees and defer signature
 # verification until `overcommit --sign` has run in this worktree (via fix.sh).
 require 'yaml'
 require 'fileutils'
@@ -15,18 +15,29 @@ rescue StandardError
   nil
 end
 
+# @param repo_root [String]
+# @return [String, nil]
+def sibling_worktree_local_overcommit(repo_root)
+  String(`git worktree list --porcelain 2>/dev/null`).each_line do |line|
+    next unless line.start_with?('worktree ')
+
+    worktree = line.delete_prefix('worktree ').strip
+    next if worktree == repo_root
+
+    candidate = File.join(worktree, '.local-overcommit.yml')
+    return candidate if File.exist?(candidate)
+  end
+  nil
+end
+
 repo_root = String(`git rev-parse --show-toplevel 2>/dev/null`).strip
 exit if repo_root.empty?
 
 local_file = File.join(repo_root, '.local-overcommit.yml')
-worktrees_prefix = File.expand_path('~/.cursor/worktrees')
 
-if !File.exist?(local_file) && repo_root.start_with?("#{worktrees_prefix}/")
-  rel = repo_root.delete_prefix("#{worktrees_prefix}/")
-  repo_name = rel.split('/').first
-  source = File.join(File.expand_path('~/src'), repo_name, '.local-overcommit.yml')
-  # @sg-ignore FileUtils.ln_sf src path typing in bootstrap hook
-  FileUtils.ln_sf(source, local_file) if File.exist?(source)
+unless File.exist?(local_file)
+  source = sibling_worktree_local_overcommit(repo_root)
+  FileUtils.ln_sf(source, local_file) if source
 end
 
 return unless File.exist?(local_file)
@@ -35,5 +46,5 @@ raw_config = load_local_overcommit_config(local_file)
 return unless raw_config&.[]('verify_signatures') == false
 
 signed = String(`git config --local --get overcommit.configuration.verifysignatures 2>/dev/null`).strip
-# @sg-ignore ENV[]= not resolved on ENV class in Solargraph
+# @sg-ignore Unresolved call to []= on RBS::Unnamed::ENVClass
 ENV['OVERCOMMIT_NO_VERIFY'] = '1' if signed != '0'

--- a/{{cookiecutter.project_slug}}/.git-hooks/bootstrap_local_overcommit.rb
+++ b/{{cookiecutter.project_slug}}/.git-hooks/bootstrap_local_overcommit.rb
@@ -37,6 +37,7 @@ local_file = File.join(repo_root, '.local-overcommit.yml')
 
 unless File.exist?(local_file)
   source = sibling_worktree_local_overcommit(repo_root)
+  # @sg-ignore FileUtils.ln_sf src path typing in bootstrap hook
   FileUtils.ln_sf(source, local_file) if source
 end
 

--- a/{{cookiecutter.project_slug}}/.git-hooks/bootstrap_local_overcommit.rb
+++ b/{{cookiecutter.project_slug}}/.git-hooks/bootstrap_local_overcommit.rb
@@ -1,7 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
-# Link machine-local Overcommit config into Cursor worktrees and defer signature
+# Link machine-local Overcommit config across git worktrees and defer signature
 # verification until `overcommit --sign` has run in this worktree (via fix.sh).
 require 'yaml'
 require 'fileutils'
@@ -15,18 +15,29 @@ rescue StandardError
   nil
 end
 
+# @param repo_root [String]
+# @return [String, nil]
+def sibling_worktree_local_overcommit(repo_root)
+  String(`git worktree list --porcelain 2>/dev/null`).each_line do |line|
+    next unless line.start_with?('worktree ')
+
+    worktree = line.delete_prefix('worktree ').strip
+    next if worktree == repo_root
+
+    candidate = File.join(worktree, '.local-overcommit.yml')
+    return candidate if File.exist?(candidate)
+  end
+  nil
+end
+
 repo_root = String(`git rev-parse --show-toplevel 2>/dev/null`).strip
 exit if repo_root.empty?
 
 local_file = File.join(repo_root, '.local-overcommit.yml')
-worktrees_prefix = File.expand_path('~/.cursor/worktrees')
 
-if !File.exist?(local_file) && repo_root.start_with?("#{worktrees_prefix}/")
-  rel = repo_root.delete_prefix("#{worktrees_prefix}/")
-  repo_name = rel.split('/').first
-  source = File.join(File.expand_path('~/src'), repo_name, '.local-overcommit.yml')
-  # @sg-ignore FileUtils.ln_sf src path typing in bootstrap hook
-  FileUtils.ln_sf(source, local_file) if File.exist?(source)
+unless File.exist?(local_file)
+  source = sibling_worktree_local_overcommit(repo_root)
+  FileUtils.ln_sf(source, local_file) if source
 end
 
 return unless File.exist?(local_file)
@@ -35,5 +46,5 @@ raw_config = load_local_overcommit_config(local_file)
 return unless raw_config&.[]('verify_signatures') == false
 
 signed = String(`git config --local --get overcommit.configuration.verifysignatures 2>/dev/null`).strip
-# @sg-ignore ENV[]= not resolved on ENV class in Solargraph
+# @sg-ignore Unresolved call to []= on RBS::Unnamed::ENVClass
 ENV['OVERCOMMIT_NO_VERIFY'] = '1' if signed != '0'


### PR DESCRIPTION
## Summary

- Update `bootstrap_local_overcommit.rb` at repo root and `{{cookiecutter.project_slug}}/` to symlink `.local-overcommit.yml` from any sibling git worktree (via `git worktree list`), replacing Cursor-only `~/.cursor/worktrees` path logic.
- Ruby-wide: applies to gem and Rails generated repos that ship this hook.

Reference: baked gem `origin/main` at `fdaf473`.

## Test plan

- [ ] CI green

Made with [Cursor](https://cursor.com)