### PR TITLE
Ignore .gem_rbs_collection in Ruby template .gitignore

### DIFF
--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -33,6 +33,8 @@ commands:
   set_up_environment:
     description: "Install source environment"
     steps:
+      # Blobless default checkout lacks objects for tools that diff against origin/main
+      # (e.g. undercover Rugged::OdbError). CircleCI uses method: full.
       - checkout:
           method: full
       - run:

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -84,3 +84,5 @@ sorbet/machine_specific_config
 
 # Ignore 1Password-generated secrets
 /config/env
+
+/.gem_rbs_collection


### PR DESCRIPTION
## Summary
- Add `/.gem_rbs_collection` to nested template `.gitignore` (baked `99f0a5c`)
- Split out of [cookiecutter-rails #160](https://github.com/apiology/cookiecutter-rails/pull/160) — this is Ruby/Sorbet boilerplate, not Rails-specific

## Test plan
- [ ] CI green