### PR TITLE
Port Solargraph ENV union guidance and annotation stubs

### DIFF
--- a/{{cookiecutter.project_slug}}/.cursor/skills/solargraph-typecheck/SKILL.md
+++ b/{{cookiecutter.project_slug}}/.cursor/skills/solargraph-typecheck/SKILL.md
@@ -70,6 +70,85 @@ ruby .cursor/skills/solargraph-typecheck/scripts/strip_sg_ignore.rb path/to/file
 
 ## Fix patterns (prefer these over ignores)
 
+### Prefer `config/annotations_*.rb` stubs for opaque stdlib / gem APIs
+
+When Solargraph reports `Unresolved call to …` on a **stdlib or gem** method you do not own (e.g. `FileUtils.ln_sf`), prefer a YARD `@!parse` / `@!override` stub in `config/annotations_*.rb` (loaded via `.solargraph.yml` `include: config/annotations*.rb`) over a per-call-site `@sg-ignore`.
+
+```ruby
+# config/annotations_misc.rb
+# @!override FileUtils.ln_sf
+#   @param src [String]
+#   @param dest [String]
+#   @return [void]
+#
+# @!parse
+#   module FileUtils
+#     class << self
+#       # @param src [String]
+#       # @param dest [String]
+#       # @return [void]
+#       def ln_sf(src, dest, **options); end
+#     end
+#   end
+```
+
+**ENV caveat (Solargraph 0.59+):** do **not** add a YARD `class ENV` stub. Under strong, Solargraph **unions** pins for the `ENV` constant:
+
+1. Stdlib RBS → `RBS::Unnamed::ENVClass` (has `[]` / `[]=` / `fetch`).
+2. Ruby-core / constant pin → still includes a `Class<ENV>` view of the same top-level object.
+
+Method lookup on a union requires the method on **every** member. `[]` exists on `ENVClass` but not on `Class<ENV>`, so strong reports unresolved calls even though RBS is correct. A YARD `class ENV` stub adds another pin and makes the union worse.
+
+Prefer:
+
+1. Remove any local `class ENV` YARD stub.
+2. Keep normal `ENV[key]` / `ENV[key] = value` / `ENV.fetch(...)` call sites.
+3. When strong reports unresolved `[]` / `[]=` / `fetch` on `RBS::Unnamed::ENVClass, Class<ENV>`, use a one-line `# @sg-ignore` with the exact error text (optional two-space continuation noting the union bug for upstream mining).
+4. **Do not** use `ENV.send(:[], …)` / `ENV.send(:[]=, …)`. That only replaces conventional ENV access (which Solargraph rejects) with unconventional code that Solargraph happens not to flag — it does **not** typecheck any better, and reviewers reject it.
+
+For `YAML.load_file`, strong will reject `# @type […]` on the assignment unless the method’s return type is known — stub `Psych.load_file` / `YAML.load_file` in `config/annotations_*.rb` returning `Object, nil`, then annotate the local with `# @type [Object, nil]`.
+
+Only fall back to a one-line `# @sg-ignore` when an annotation stub does not take effect after re-running strong typecheck (some early boot / binstub paths still need ignores).
+
+### Document unresolved parameters (including block params)
+
+When Solargraph cannot resolve a call on a method or block parameter (`Unresolved call to …`), add a YARD `# @param` (or `# @type` on a local) for that parameter **before** reaching for `@sg-ignore`. Do this for **every** parameter on the failing call (including block params and `proc`/`lambda` args).
+
+**Block params:** put `# @param` on the line(s) **immediately above** the iterator/`find_each`/`map` call — **never inside** the `do … end` / `{ … }` body. A tag after `do` is easy to write and usually ignored by Solargraph.
+
+```ruby
+# good — @param above the block
+# @param record [SomeModel]
+stale_records.each do |record|
+  record.refresh
+end
+
+# bad — @param inside the block (do not do this)
+stale_records.each do |record|
+  # @param record [SomeModel]
+  record.refresh
+end
+```
+
+Prefer annotating the real method in-repo (`# @param` / `# @return` on the definition) over a parallel stub in `config/annotations_*.rb` when the method lives in this repository.
+
+### Fix “return type could not be inferred” before `@sg-ignore`
+
+When strong reports `Class#method return type could not be inferred` even with `# @return […]` present, **first** make the body inferable:
+
+1. Assign the result to a local with `# @type […]` matching the `@return`, then return that local.
+2. If the RHS method itself is undefined (e.g. `YAML.load_file`, opaque gem APIs), add a `config/annotations_*.rb` stub for that method’s return type, then retry.
+3. Only then use `# @sg-ignore … return type could not be inferred` — and note in the ignore or a nearby comment if a stub was tried and failed.
+
+```ruby
+# @return [Hash{Symbol => Object}]
+def metric_to_hash(metric)
+  # @type [Hash{Symbol => Object}]
+  result = metric.to_h.symbolize_keys
+  result
+end
+```
+
 ### YARD `@param` widening
 
 CLI and option helpers may accept symbols from [GLI](https://github.com/davydovanton/gli) (Gem Library Interface) defaults. When strong reports `expected String, received String, Symbol`, widen the callee's `@param`:
@@ -103,8 +182,7 @@ Date.parse('2029-01-04')
 
 - HTTP response bodies: `@param response [#read_body]`
 - `$LOAD_PATH`: one `# @sg-ignore` on the bootstrap line (special RBS typing)
-- Bundler binstub `ENV['BUNDLE_GEMFILE'] ||= ...`: YARD stubs in `config/annotations_misc.rb` do not override RBS `ENVClass` at strong level — keep `# @sg-ignore` on each binstub line
-- `ENV.fetch(...)` may also resolve as unknown on `ENVClass` at strong level in app code; use a one-line `# @sg-ignore` directly above the call when an annotation-based fix does not stick
+- `ENV` / `FileUtils` / similar: prefer `config/annotations_*.rb` `@!parse` / `@!override` stubs where they help — see “Prefer config/annotations_*.rb stubs” above. Never add a YARD `class ENV` stub. For ENV `[]` / `[]=` / `fetch` union failures, keep normal `ENV[...]` + `# @sg-ignore`. Never `ENV.send` (unconventional code that Solargraph happens to ignore is not better typing)
 
 ### GLI command blocks
 

--- a/{{cookiecutter.project_slug}}/.cursor/skills/solargraph-typecheck/SKILL.md
+++ b/{{cookiecutter.project_slug}}/.cursor/skills/solargraph-typecheck/SKILL.md
@@ -182,7 +182,7 @@ Date.parse('2029-01-04')
 
 - HTTP response bodies: `@param response [#read_body]`
 - `$LOAD_PATH`: one `# @sg-ignore` on the bootstrap line (special RBS typing)
-- `ENV` / `FileUtils` / similar: prefer `config/annotations_*.rb` `@!parse` / `@!override` stubs where they help — see “Prefer config/annotations_*.rb stubs” above. Never add a YARD `class ENV` stub. For ENV `[]` / `[]=` / `fetch` union failures, keep normal `ENV[...]` + `# @sg-ignore`. Never `ENV.send` (unconventional code that Solargraph happens to ignore is not better typing)
+- `ENV` / `FileUtils` / similar: prefer `config/annotations_*.rb` `@!parse` / `@!override` stubs where they help — see “Prefer config/annotations_*.rb stubs” above. Never add a YARD `class ENV` stub. For ENV `[]` / `[]=` / `fetch` union failures that still appear after removing that stub, keep normal `ENV[...]` + `# @sg-ignore`. Never `ENV.send`. Remove **Unneeded @sg-ignore** on binstubs/`FileUtils` once stubs land and strong is clean
 
 ### GLI command blocks
 

--- a/{{cookiecutter.project_slug}}/.cursor/skills/solargraph-typecheck/references/issue-catalog.md
+++ b/{{cookiecutter.project_slug}}/.cursor/skills/solargraph-typecheck/references/issue-catalog.md
@@ -62,17 +62,23 @@ Quick lookup for strong-level messages seen in Ruby gem repos and the preferred 
 
 **Fix:** `# @type [Overcommit::Subprocess::Result]` on the assignment line.
 
-## Unresolved call to [] on RBS::Unnamed::ENVClass (binstubs)
+## Unresolved call to [] / []= / fetch on RBS::Unnamed::ENVClass
 
-**Cause:** `$LOAD_PATH`-style special typing in binstubs.
+**Cause:** Solargraph unions pins for `ENV`: stdlib RBS `RBS::Unnamed::ENVClass` (has `[]` / `[]=` / `fetch`) **and** a Ruby-core `Class<ENV>` view of the same constant. Strong method lookup on a union requires the method on every member, so calls fail even though `ENVClass` defines them. A YARD `class ENV` stub adds another pin and makes the union worse — that is the “widening,” not a missing stub.
 
-**Fix:** Usually ignorable on the `ENV['BUNDLE_GEMFILE']` line; binstubs are often excluded or get a single ignore.
+**Fix:** Remove any `class ENV` YARD stub. Keep normal `ENV[key]` / `ENV[key] = value` / `ENV.fetch(...)` and add a targeted `# @sg-ignore` with the strong error text. **Do not** use `ENV.send(:[], …)` / `ENV.send(:[]=, …)` — that only swaps conventional rejected ENV access for unconventional code Solargraph happens to ignore; it does not typecheck any better. Document in `config/annotations_misc.rb` so agents do not reintroduce a `class ENV` stub or an `ENV.send` workaround.
 
-## Unresolved call to fetch on RBS::Unnamed::ENVClass
+## Unresolved call to FileUtils.ln_sf (or similar stdlib module methods)
 
-**Cause:** Strong-level RBS typing for `ENV` may not expose `fetch` in all contexts.
+**Cause:** Incomplete or overly narrow Solargraph/RBS pins for the method (e.g. `FileUtils::path` rejecting plain `String`).
 
-**Fix:** Add a targeted `# @sg-ignore` immediately above `ENV.fetch(...)` when a cleaner type annotation does not resolve it.
+**Fix:** Add a `@!parse` / `@!override` stub under `module FileUtils` in `config/annotations_*.rb` that accepts `String`, then re-run strong typecheck. Do not default to `@sg-ignore` for methods you can document once.
+
+## Variable type could not be inferred (with `# @type` present)
+
+**Cause:** Strong validates that a declared `@type` matches a probed inferred type. If the RHS method return is undefined (common for `YAML.load_file`), validation fails with this message even though `@type` is present.
+
+**Fix:** Stub the RHS method return in `config/annotations_*.rb` (e.g. `Psych`/`YAML.load_file` → `Object, nil`), then keep `# @type [Object, nil]` on the assignment.
 
 ## Unresolved constant WARN
 

--- a/{{cookiecutter.project_slug}}/.git-hooks/bootstrap_local_overcommit.rb
+++ b/{{cookiecutter.project_slug}}/.git-hooks/bootstrap_local_overcommit.rb
@@ -25,7 +25,6 @@ if !File.exist?(local_file) && repo_root.start_with?("#{worktrees_prefix}/")
   rel = repo_root.delete_prefix("#{worktrees_prefix}/")
   repo_name = rel.split('/').first
   source = File.join(File.expand_path('~/src'), repo_name, '.local-overcommit.yml')
-  # @sg-ignore FileUtils.ln_sf src path typing in bootstrap hook
   FileUtils.ln_sf(source, local_file) if File.exist?(source)
 end
 
@@ -35,5 +34,4 @@ raw_config = load_local_overcommit_config(local_file)
 return unless raw_config&.[]('verify_signatures') == false
 
 signed = String(`git config --local --get overcommit.configuration.verifysignatures 2>/dev/null`).strip
-# @sg-ignore Unresolved call to []= on RBS::Unnamed::ENVClass
 ENV['OVERCOMMIT_NO_VERIFY'] = '1' if signed != '0'

--- a/{{cookiecutter.project_slug}}/bin/fasterer
+++ b/{{cookiecutter.project_slug}}/bin/fasterer
@@ -8,7 +8,6 @@
 # this file is here to facilitate running it.
 #
 
-# @sg-ignore
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 bundle_binstub = File.expand_path("bundle", __dir__)

--- a/{{cookiecutter.project_slug}}/bin/overcommit
+++ b/{{cookiecutter.project_slug}}/bin/overcommit
@@ -9,7 +9,6 @@
 #
 
 require 'pathname'
-# @sg-ignore
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile',
                                            Pathname.new(__FILE__).realpath)
 

--- a/{{cookiecutter.project_slug}}/bin/parlour
+++ b/{{cookiecutter.project_slug}}/bin/parlour
@@ -8,7 +8,6 @@
 # this file is here to facilitate running it.
 #
 
-# @sg-ignore
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 bundle_binstub = File.expand_path("bundle", __dir__)

--- a/{{cookiecutter.project_slug}}/bin/rake
+++ b/{{cookiecutter.project_slug}}/bin/rake
@@ -9,7 +9,6 @@
 #
 
 require "pathname"
-# @sg-ignore
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 

--- a/{{cookiecutter.project_slug}}/bin/rbs
+++ b/{{cookiecutter.project_slug}}/bin/rbs
@@ -8,7 +8,6 @@
 # this file is here to facilitate running it.
 #
 
-# @sg-ignore
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 bundle_binstub = File.expand_path("bundle", __dir__)

--- a/{{cookiecutter.project_slug}}/bin/rubocop
+++ b/{{cookiecutter.project_slug}}/bin/rubocop
@@ -8,7 +8,6 @@
 # this file is here to facilitate running it.
 #
 
-# @sg-ignore
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 bundle_binstub = File.expand_path("bundle", __dir__)

--- a/{{cookiecutter.project_slug}}/bin/solargraph
+++ b/{{cookiecutter.project_slug}}/bin/solargraph
@@ -8,7 +8,6 @@
 # this file is here to facilitate running it.
 #
 
-# @sg-ignore
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 bundle_binstub = File.expand_path("bundle", __dir__)

--- a/{{cookiecutter.project_slug}}/bin/sord
+++ b/{{cookiecutter.project_slug}}/bin/sord
@@ -8,7 +8,6 @@
 # this file is here to facilitate running it.
 #
 
-# @sg-ignore
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 bundle_binstub = File.expand_path("bundle", __dir__)

--- a/{{cookiecutter.project_slug}}/bin/spoom
+++ b/{{cookiecutter.project_slug}}/bin/spoom
@@ -8,7 +8,6 @@
 # this file is here to facilitate running it.
 #
 
-# @sg-ignore
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 bundle_binstub = File.expand_path("bundle", __dir__)

--- a/{{cookiecutter.project_slug}}/bin/srb
+++ b/{{cookiecutter.project_slug}}/bin/srb
@@ -8,7 +8,6 @@
 # this file is here to facilitate running it.
 #
 
-# @sg-ignore
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 bundle_binstub = File.expand_path("bundle", __dir__)

--- a/{{cookiecutter.project_slug}}/bin/tapioca
+++ b/{{cookiecutter.project_slug}}/bin/tapioca
@@ -8,7 +8,6 @@
 # this file is here to facilitate running it.
 #
 
-# @sg-ignore
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 bundle_binstub = File.expand_path("bundle", __dir__)

--- a/{{cookiecutter.project_slug}}/bin/yard
+++ b/{{cookiecutter.project_slug}}/bin/yard
@@ -8,7 +8,6 @@
 # this file is here to facilitate running it.
 #
 
-# @sg-ignore
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 bundle_binstub = File.expand_path("bundle", __dir__)

--- a/{{cookiecutter.project_slug}}/config/annotations_misc.rb
+++ b/{{cookiecutter.project_slug}}/config/annotations_misc.rb
@@ -15,22 +15,66 @@
 # @!override Hash<[String,Symbol],String>#fetch
 #   @return [String>]
 #
+# Do not add a YARD `class ENV` stub here. What Solargraph does under strong:
+#
+# 1. Stdlib RBS defines `ENV` as the singleton-like `RBS::Unnamed::ENVClass`
+#    with instance methods `[]`, `[]=`, `fetch`, etc.
+# 2. Separately, Solargraph still keeps a Ruby-core / constant pin that treats
+#    `ENV` as related to `::ENV` / `Class<ENV>` (the top-level ENV object's
+#    class-ish view of the same constant).
+# 3. At call sites, those pins are **unioned**. Strong then probes methods on
+#    `RBS::Unnamed::ENVClass, Class<ENV>`. Lookup requires the method to exist
+#    on *every* member of a union; `[]` / `[]=` / `fetch` exist on `ENVClass`
+#    but not on `Class<ENV>`, so the call is reported unresolved even though
+#    the RBS half is correct.
+# 4. Adding a YARD `class ENV` stub adds yet another pin and makes the union
+#    wider / worse — it does not replace the RBS type.
+#
+# Keep normal `ENV[...]` / `ENV[]=` / `ENV.fetch` call sites and use a one-line
+# Solargraph ignore (`sg-ignore`) with the strong error text when the union
+# fails. Do not use `ENV.send` — that only swaps conventional rejected ENV
+# access for unconventional code that Solargraph happens to ignore; it does not
+# typecheck any better.
+#
+# @!override FileUtils.ln_sf
+#   @param src [String]
+#   @param dest [String]
+#   @param options [Hash]
+#   @return [void]
+#
+# @!override YAML.load_file
+#   @param path [String]
+#   @return [Object, nil]
+#
 # @!parse
-#   class ENV
-#     # @param key [String]
-#     # @param default [Object]
-#     #
-#     # @return [String,:none,nil]
-#     def self.fetch(key, default = :none); end
-#     # @param key [String]
-#     #
-#     # @return [Object,nil]
-#     def self.[](key); end
-#     # @param key [String]
-#     # @param value [Object,nil]
-#     #
-#     # @return [Object,nil]
-#     def self.[]=(key,value); end
+#   module Psych
+#     class << self
+#       # @param path [String]
+#       # @return [Object, nil]
+#       def load_file(path); end
+#     end
+#   end
+#   module YAML
+#     class << self
+#       # @param path [String]
+#       # @return [Object, nil]
+#       def load_file(path); end
+#     end
+#   end
+#   module FileUtils
+#     class << self
+#       # Accept String paths — stdlib RBS FileUtils::path is overly narrow under
+#       # Solargraph strong for plain String call sites.
+#       # @param src [String]
+#       # @param dest [String]
+#       # @param options [Hash]
+#       # @return [void]
+#       def ln_sf(src, dest, **options); end
+#     end
+#   end
+#   class StringIO
+#     # @return [String]
+#     def string; end
 #   end
 #   module Bundler
 #     class << self
@@ -55,7 +99,7 @@
 #       # @return [Time]
 #       def parse(time, now=nil); end
 #     end
-#     # https://ruby-doc.org/3.2.2/exts/date/Time.html#method-i-to_date#
+#     # https://ruby-doc.org/3.2.2/exts/date/Time.html#method-i-to-date#
 #     # @return [Date]
 #     def to_date; end
 #   end


### PR DESCRIPTION
## Summary
- Drop the YARD `class ENV` stub in `config/annotations_misc.rb` (it widens Solargraph’s `ENVClass|Class<ENV>` union under strong) and document the correct ignore pattern.
- Add `FileUtils.ln_sf`, `Psych`/`YAML.load_file`, and `StringIO#string` annotation stubs shared by Ruby gem and Rails projects.
- Extend the solargraph-typecheck skill and issue catalog with ENV/FileUtils/YAML fix patterns, block-`@param` placement, and return-type inference guidance.
- Remove stale `# @sg-ignore` on Bundler binstubs and bootstrap once those stubs make the prior ignores unneeded under strong.

**Added:** ENV union documentation; FileUtils/YAML/Psych/StringIO stubs; skill/catalog guidance.
**Removed:** YARD `class ENV` stub; outdated binstub-only ENV catalog entries; unneeded `@sg-ignore` on binstubs/`FileUtils.ln_sf`/`ENV[]=` in bootstrap.

## Test plan
- [ ] CI `build` (bake + `make typecheck`) green
- [ ] Skim `config/annotations_misc.rb` — no `class ENV` YARD stub; FileUtils/YAML stubs present
- [ ] Confirm skill still keeps `{{cookiecutter.project_slug}}` in the build-typecheck bullet