### PR TITLE
Upgrade rubocop, rubocop-yard, and yard

### DIFF
--- a/{{cookiecutter.project_slug}}/.rubocop.yml
+++ b/{{cookiecutter.project_slug}}/.rubocop.yml
@@ -166,7 +166,7 @@ Metrics:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   Exclude:
     - 'bin/*'
     - 'vendor/**/*'
@@ -177,7 +177,3 @@ plugins:
   - rubocop-rake
   - rubocop-rspec
   - rubocop-yard
-
-# rubocop-yard 1.1.0 crashes (NilClass in styled_string) on Hash{K => V} inside unions
-YARD/CollectionStyle:
-  Enabled: false

--- a/{{cookiecutter.project_slug}}/.rubocop.yml
+++ b/{{cookiecutter.project_slug}}/.rubocop.yml
@@ -177,3 +177,7 @@ plugins:
   - rubocop-rake
   - rubocop-rspec
   - rubocop-yard
+
+# rubocop-yard 1.1.0 crashes (NilClass in styled_string) on Hash{K => V} inside unions
+YARD/CollectionStyle:
+  Enabled: false

--- a/{{cookiecutter.project_slug}}/Gemfile
+++ b/{{cookiecutter.project_slug}}/Gemfile
@@ -32,17 +32,16 @@ group :development do
   gem 'fasterer'
   gem 'overcommit', '~>0.69.0'
   gem 'punchlist', ['>=1.3.1']
-  gem 'rubocop', ['~> 1.52']
+  gem 'rubocop', ['~> 1.88']
   gem 'rubocop-performance'
   gem 'rubocop-rake'
-  gem 'rubocop-yard'
+  # >= 1.3.0 guards YARD/CollectionStyle against yard Hash-union parser mismatch
+  gem 'rubocop-yard', ['>= 1.3.0']
   # ensure version with RSpec/VerifiedDoubleReference
   gem 'rubocop-rspec', ['>=3.4.0']
   gem 'solargraph', ['>=0.56']
-  # need https://github.com/lsegal/yard/pull/1604
-  gem 'yard',
-      github: 'lsegal/yard',
-      branch: 'main'
+  # >= 0.9.44 includes https://github.com/lsegal/yard/pull/1604
+  gem 'yard', ['>= 0.9.44']
   gem 'yard-sorbet'
 end
 

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -32,7 +32,7 @@ rbi/{{cookiecutter.project_slug}}.rbi: tapioca.installed yardoc.installed sorbet
 	bin/sord gen $(SORD_GEN_OPTIONS) rbi/{{cookiecutter.project_slug}}-sord.rbi # YARD to RBI
 	cat rbi/{{cookiecutter.project_slug}}-parlour.rbi rbi/{{cookiecutter.project_slug}}-sord.rbi > rbi/{{cookiecutter.project_slug}}.rbi
 	rm -f rbi/{{cookiecutter.project_slug}}-sord.rbi rbi/{{cookiecutter.project_slug}}-parlour.rbi
-	sed -i.bak -e 's/^# typed: strong/# typed: ignore/' rbi/{{cookiecutter.project_slug}}.rbi
+#	sed -i.bak -e 's/^# typed: strong/# typed: ignore/' rbi/{{cookiecutter.project_slug}}.rbi
 	rm -f rbi/{{cookiecutter.project_slug}}.rbi.bak
 	touch rbi/{{cookiecutter.project_slug}}.rbi
 

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -32,7 +32,7 @@ rbi/{{cookiecutter.project_slug}}.rbi: tapioca.installed yardoc.installed sorbet
 	bin/sord gen $(SORD_GEN_OPTIONS) rbi/{{cookiecutter.project_slug}}-sord.rbi # YARD to RBI
 	cat rbi/{{cookiecutter.project_slug}}-parlour.rbi rbi/{{cookiecutter.project_slug}}-sord.rbi > rbi/{{cookiecutter.project_slug}}.rbi
 	rm -f rbi/{{cookiecutter.project_slug}}-sord.rbi rbi/{{cookiecutter.project_slug}}-parlour.rbi
-#	sed -i.bak -e 's/^# typed: strong/# typed: ignore/' rbi/{{cookiecutter.project_slug}}.rbi
+	sed -i.bak -e 's/^# typed: strong/# typed: ignore/' rbi/{{cookiecutter.project_slug}}.rbi
 	rm -f rbi/{{cookiecutter.project_slug}}.rbi.bak
 	touch rbi/{{cookiecutter.project_slug}}.rbi
 


### PR DESCRIPTION
## Summary
- Bump nested template `rubocop` to `~> 1.88`, pin `rubocop-yard` to `>= 1.3.0` (guards `YARD/CollectionStyle` against yard Hash-union parser mismatch), and switch `yard` from GitHub `main` to released `>= 0.9.44` (includes the word-array parse fix).
- Set `TargetRubyVersion` to 3.3 to match `rubocop-yard` 1.3’s Ruby requirement and the template’s Ruby 3.3 bootstrap.
- Do **not** force an RBI `# typed: ignore` sed rewrite for all projects.

**Added:** Gemfile version floors; `TargetRubyVersion: 3.3`.
**Removed:** none vs `origin/main`.

## Test plan
- [ ] Nested `Gemfile` shows the new pins; no github `yard` source
- [ ] Nested `.rubocop.yml` has `TargetRubyVersion: 3.3` and no `YARD/CollectionStyle` disable
- [ ] Nested `Makefile` RBI `sed` remains commented
- [ ] CI green on this PR