### PR TITLE
Drive RegenerateTypecheck from Makefile lock deps

### DIFF
--- a/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/regenerate_typecheck.rb
+++ b/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/regenerate_typecheck.rb
@@ -15,8 +15,9 @@ module Overcommit
           result = execute(%w[make build-typecheck])
           return [:fail, result.stdout + result.stderr] unless result.success?
 
+          # @type [Array<String>]
           paths_to_stage = execute(%w[make -s echo-regenerate-typecheck-paths]).stdout.split
-          paths_to_stage.select! { |path| File.exist?(path) }
+          paths_to_stage = paths_to_stage.select { |path| File.exist?(path) }
           return :pass if paths_to_stage.empty?
 
           # @type [Overcommit::Subprocess::Result]

--- a/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/regenerate_typecheck.rb
+++ b/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/regenerate_typecheck.rb
@@ -16,6 +16,7 @@ module Overcommit
           return [:fail, result.stdout + result.stderr] unless result.success?
 
           paths_to_stage = execute(%w[make -s echo-regenerate-typecheck-paths]).stdout.split
+          paths_to_stage.select! { |path| File.exist?(path) }
           return :pass if paths_to_stage.empty?
 
           # @type [Overcommit::Subprocess::Result]

--- a/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/regenerate_typecheck.rb
+++ b/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/regenerate_typecheck.rb
@@ -9,30 +9,13 @@ module Overcommit
     module PreCommit
       # Regenerates typechecking artifacts when Gemfile.lock is committed.
       class RegenerateTypecheck < Base
-        # Tracked paths updated by `make build-typecheck` (see Makefile).
-        BUILD_TYPECHECK_PATHS = [
-          'sorbet/rbi/gems',
-          'sorbet/rbi/annotations',
-          'sorbet/rbi/dsl',
-          'sorbet/rbi/todo.rbi',
-          'rbs_collection.lock.yaml',
-          'rbi',
-        ].freeze
-
-        STAMP_FILES = %w[
-          tapioca.installed
-          Gemfile.lock.installed
-          types.installed
-        ].freeze
-
         # @return [Symbol, Array<Symbol, String>]
         def run
-          execute(['rm', '-f', *STAMP_FILES])
           # @type [Overcommit::Subprocess::Result]
           result = execute(%w[make build-typecheck])
           return [:fail, result.stdout + result.stderr] unless result.success?
 
-          paths_to_stage = BUILD_TYPECHECK_PATHS.select { |path| File.exist?(path) }
+          paths_to_stage = execute(%w[make -s echo-regenerate-typecheck-paths]).stdout.split
           return :pass if paths_to_stage.empty?
 
           # @type [Overcommit::Subprocess::Result]

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -76,6 +76,13 @@ sorbet/rbi/todo.rbi: sorbet/tapioca/require.rb rbi/{{cookiecutter.project_slug}}
 
 build-typecheck: Gemfile.lock.installed rbs_collection.lock.yaml types.installed sorbet/machine_specific_config sorbet/rbi/todo.rbi ## Fetch information that type checking depends on
 
+# RegenerateTypecheck hook: paths to stage (see .git-hooks/pre_commit/regenerate_typecheck.rb)
+REGENERATE_TYPECHECK_PATHS := sorbet/rbi/gems sorbet/rbi/annotations sorbet/rbi/dsl sorbet/rbi/todo.rbi rbs_collection.lock.yaml rbi
+
+.PHONY: echo-regenerate-typecheck-paths
+echo-regenerate-typecheck-paths:
+	@echo $(REGENERATE_TYPECHECK_PATHS)
+
 rbs_collection.lock.yaml: Gemfile.lock rbs_collection.yaml
 	bin/rbs collection update
 	touch rbs_collection.lock.yaml
@@ -96,7 +103,7 @@ sorbet/tapioca/require.rb:
 	make sorbet/machine_specific_config vendor/.keep
 	bin/tapioca init
 
-tapioca.installed: sorbet/tapioca/require.rb Gemfile.lock.installed ## Install Tapioca-generated type information
+tapioca.installed: sorbet/tapioca/require.rb Gemfile.lock Gemfile.lock.installed ## Install Tapioca-generated type information
 	make sorbet/machine_specific_config
 	bin/tapioca gems
 	bin/tapioca annotations
@@ -183,7 +190,7 @@ gem_dependencies: .bundle/config
 
 # Ensure any Gemfile.lock changes, even pulled from git, ensure a
 # bundle is installed.
-Gemfile.lock.installed: Gemfile vendor/.keep
+Gemfile.lock.installed: Gemfile Gemfile.lock vendor/.keep
 	bundle install
 	touch Gemfile.lock.installed
 

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -77,7 +77,7 @@ sorbet/rbi/todo.rbi: sorbet/tapioca/require.rb rbi/{{cookiecutter.project_slug}}
 build-typecheck: Gemfile.lock.installed rbs_collection.lock.yaml types.installed sorbet/machine_specific_config sorbet/rbi/todo.rbi ## Fetch information that type checking depends on
 
 # RegenerateTypecheck hook: paths to stage (see .git-hooks/pre_commit/regenerate_typecheck.rb)
-REGENERATE_TYPECHECK_PATHS := sorbet/rbi/gems sorbet/rbi/annotations sorbet/rbi/dsl sorbet/rbi/todo.rbi rbs_collection.lock.yaml rbi
+REGENERATE_TYPECHECK_PATHS := sorbet/rbi/gems sorbet/rbi/annotations sorbet/rbi/todo.rbi rbs_collection.lock.yaml rbi
 
 .PHONY: echo-regenerate-typecheck-paths
 echo-regenerate-typecheck-paths:


### PR DESCRIPTION
## Summary
- Point RegenerateTypecheck at `make echo-regenerate-typecheck-paths` instead of hardcoded path/stamp lists, and stop deleting stamp files before `make build-typecheck`.
- Add Gemfile.lock as a Make dependency of tapioca.installed and Gemfile.lock.installed so lockfile changes rebuild typecheck artifacts through normal deps.
- Only git-add paths that exist after typecheck (bake projects do not create sorbet/rbi/dsl when tapioca dsl is unused).

**Added:** REGENERATE_TYPECHECK_PATHS / echo-regenerate-typecheck-paths in the project Makefile; Gemfile.lock on tapioca and bundle install stamp targets; exist-filter before staging.
**Removed:** hardcoded BUILD_TYPECHECK_PATHS / STAMP_FILES and rm -f stamp clearing from regenerate_typecheck.rb; sorbet/rbi/dsl from the default path list.

## Test plan
- [ ] Confirm `make -s echo-regenerate-typecheck-paths` prints the expected path list in a baked checkout from this template
- [ ] Touch Gemfile.lock and verify `make build-typecheck` rebuilds tapioca without manually deleting *.installed stamps
- [ ] Run Overcommit RegenerateTypecheck on a Gemfile.lock change and confirm staging still works when sorbet/rbi/dsl is absent