### PR TITLE
Update from cookiecutter-cookiecutter + .claude Solargraph exclusion

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -70,10 +70,6 @@ PreCommit:
       - 'core.*'
       # don't freak out over line below
       - '.overcommit.yml'
-  CustomScript:
-    enabled: true
-    requires_files: false
-    required_executable: 'bin/git-commit-validate'
   BundleInstall:
     enabled: true
   ALL:

--- a/bin/git-commit-validate
+++ b/bin/git-commit-validate
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-if [ -x "$HOME/bin/git-commit-validate" ]; then
-    exec "$HOME/bin/git-commit-validate" "$@"
-fi

--- a/docs/cookiecutter_input.json
+++ b/docs/cookiecutter_input.json
@@ -1,6 +1,6 @@
 {
     "_checkout": "main",
-    "_output_dir": "/Users/broz/src/cookiecutter-ruby/.claude/worktrees/update-from-cookiecutter/.git/cookiecutter",
+    "_output_dir": "/Users/broz/src/cookiecutter-ruby/.claude/worktrees/update-from-cookiecutter-and-fixes/.git/cookiecutter",
     "_repo_dir": "/Users/broz/.cookiecutters/cookiecutter-cookiecutter",
     "_template": "https://github.com/apiology/cookiecutter-cookiecutter",
     "email": "vince@broz.cc",

--- a/{{cookiecutter.project_slug}}/.overcommit.yml
+++ b/{{cookiecutter.project_slug}}/.overcommit.yml
@@ -103,8 +103,9 @@ PreCommit:
       - "bin/*"
       - "bin/overcommit_branch"
     exclude:
-      # Cursor skills/scripts are agent tooling, not gem API surface
+      # Cursor/Claude skills and scripts are agent tooling, not gem API surface
       - '.cursor/**/*'
+      - '.claude/**/*'
       # vendored
       - 'bin/bundle'
       - 'bin/brakeman'

--- a/{{cookiecutter.project_slug}}/.overcommit.yml
+++ b/{{cookiecutter.project_slug}}/.overcommit.yml
@@ -62,10 +62,6 @@ PreCommit:
       - 'core.*'
       # don't freak out over line below
       - '.overcommit.yml'
-  CustomScript:
-    enabled: true
-    requires_files: false
-    required_executable: 'bin/git-commit-validate'
   BundleInstall:
     enabled: true
   ALL:

--- a/{{cookiecutter.project_slug}}/.solargraph.yml
+++ b/{{cookiecutter.project_slug}}/.solargraph.yml
@@ -14,8 +14,9 @@ include:
   - "bin/*"
   - "bin/overcommit_branch"
 exclude:
-  # Cursor skills/scripts are agent tooling, not gem API surface
+  # Cursor/Claude skills and scripts are agent tooling, not gem API surface
   - '.cursor/**/*'
+  - '.claude/**/*'
   # vendored
   - 'bin/bundle'
   - 'bin/brakeman'

--- a/{{cookiecutter.project_slug}}/bin/git-commit-validate
+++ b/{{cookiecutter.project_slug}}/bin/git-commit-validate
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-if [ -x "$HOME/bin/git-commit-validate" ]; then
-    exec "$HOME/bin/git-commit-validate" "$@"
-fi


### PR DESCRIPTION
## Summary

Two changes on this branch:

**1. Automated `make update_from_cookiecutter` merge.** Pulls in the stale `CustomScript`/`bin/git-commit-validate` Overcommit hook removal from `cookiecutter-cookiecutter` (merged upstream in apiology/cookiecutter-cookiecutter#637), at both the root and nested `{{cookiecutter.project_slug}}/` tiers.

**2. Add `.claude/**/*` exclusion alongside `.cursor/**/*`.** The nested Solargraph overcommit hook and `.solargraph.yml` excluded `.cursor/**/*` (agent skills are not gem API surface) but never got the equivalent `.claude/**/*` entry after the Cursor to Claude migration, so Claude skill scripts under `.claude/skills/` in baked repos were being scanned as gem API surface. Comment updated to mention both.

## Test plan

- [x] `pytest tests/test_bake_project.py` passes
- [x] `bin/overcommit --run` passes
- [x] No remaining `CustomScript`/`git-commit-validate` references anywhere in the tracked tree
